### PR TITLE
fix: sdk session expiry

### DIFF
--- a/packages/sdk/src/client-auth-server/session/index.ts
+++ b/packages/sdk/src/client-auth-server/session/index.ts
@@ -119,7 +119,7 @@ export const formatLimitPreferences = (limit: PartialLimit): Limit => {
 
 export const formatDatePreferences = (date: string | bigint | Date): bigint => {
   if (typeof date === "string") {
-    const now = new Date().getTime();
+    const now = Math.floor(new Date().getTime() / 1000);
     const seconds = msStringToSeconds(date);
     return BigInt(now) + seconds;
   }


### PR DESCRIPTION
# Description
Fix session expiry formatter for human readable time (e.g. "1 day")


## Additional context
