### PR TITLE
fix: dashboard style hotfix

### DIFF
--- a/packages/auth-server/pages/dashboard.vue
+++ b/packages/auth-server/pages/dashboard.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <header class="mb-8">
+    <header class="max-w-[1920px] mx-auto mb-8">
       <AppNav />
     </header>
-    <main class="max-w-dashboard m-auto">
+    <main class="max-w-[900px] m-auto">
       <NuxtPage />
     </main>
   </div>


### PR DESCRIPTION
# Description
Add max-width for the Auth Server dashboard content


## Additional context
Max width for auth server content seems to have been deleted at some point