### PR TITLE
chore(nft-quest): enable cors for nft metadata

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -16,7 +16,26 @@
       "target": "nft-quest-testnet",
       "trailingSlash": false,
       "public": "examples/nft-quest/.output/public",
-      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "headers": [
+        {
+          "source": "/nft/metadata.json",
+          "headers": [
+            {
+              "key": "Access-Control-Allow-Origin",
+              "value": "*"
+            },
+            {
+              "key": "Access-Control-Allow-Methods",
+              "value": "GET"
+            },
+            {
+              "key": "Access-Control-Allow-Headers",
+              "value": "Content-Type"
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Description

Set up cors to enable accessing NFT metadata from NFT Quest.