### PR TITLE
fix: increase nft-quest fee limit

### DIFF
--- a/examples/nft-quest/stores/connector.ts
+++ b/examples/nft-quest/stores/connector.ts
@@ -22,7 +22,7 @@ export const useConnectorStore = defineStore("connector", () => {
     },
     authServerUrl: runtimeConfig.public.authServerUrl,
     session: {
-      feeLimit: parseEther("0.004"),
+      feeLimit: parseEther("0.04"),
       contractCalls: [
         callPolicy({
           address: runtimeConfig.public.contracts.nft as Hash,


### PR DESCRIPTION
# Description
Increase fee limit from `0.004 ETH` to `0.04 ETH` while we investigate the gas estimation errors