### PR TITLE
fix: ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Deploy Demo-App contracts
       run: pnpm nx deploy-contracts demo-app
 
-	- name: Run tests
+    - name: Run tests
       run: pnpm test
       working-directory: packages/sdk
 


### PR DESCRIPTION
# Description

Recent ci yaml changes were tabbed instead of using spaces, creating invalid yml file
