### PR TITLE
fix: parse newly created account address from events

### DIFF
--- a/packages/sdk/src/client/passkey/actions/account.test.ts
+++ b/packages/sdk/src/client/passkey/actions/account.test.ts
@@ -33,6 +33,25 @@ vi.mock("../../../abi/Factory.js", () => ({
       stateMutability: "nonpayable",
       type: "function",
     },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: "address",
+          name: "accountAddress",
+          type: "address",
+        },
+        {
+          indexed: false,
+          internalType: "string",
+          name: "uniqueAccountId",
+          type: "string",
+        },
+      ],
+      name: "AccountCreated",
+      type: "event",
+    },
   ],
 }));
 
@@ -74,11 +93,26 @@ describe("deployAccount", () => {
   const mockTransactionHash = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" as Hash;
   const mockTransactionReceipt: TransactionReceipt = {
     status: "success",
-    contractAddress: "0x4234567890123456789012345678901234567890",
+    contractAddress: null,
     blockNumber: 1n,
     blockHash: "0x5e1d3a76f1b1c3a2b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7" as Hash,
     transactionHash: mockTransactionHash,
-    logs: [],
+    logs: [
+      {
+        address: mockContracts.accountFactory,
+        blockHash: "0x5e1d3a76f1b1c3a2b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7",
+        blockNumber: 1n,
+        data: "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001b67615039747050496b704445496c6c52504e65594b706d3264514d0000000000",
+        logIndex: 0,
+        removed: false,
+        topics: [
+          "0xb3202828e8e55b43ee1a77a1ee6ffbe19f0205767feb21e28cadd26390ff0501", // event AccountCreated(address,string)
+          "0x0000000000000000000000004234567890123456789012345678901234567890",
+        ],
+        transactionHash: "0x0b8154f57a02650c3cf622c19f1d90899d4779b3d181dfd03a53b3b257d76dd5",
+        transactionIndex: 0,
+      },
+    ],
     logsBloom: "0x",
     cumulativeGasUsed: 0n,
     effectiveGasPrice: 0n,
@@ -140,7 +174,7 @@ describe("deployAccount", () => {
     vi.mocked(writeContract).mockResolvedValue(mockTransactionHash);
     vi.mocked(waitForTransactionReceipt).mockResolvedValue({
       ...mockTransactionReceipt,
-      contractAddress: null,
+      logs: [],
     });
 
     await expect(


### PR DESCRIPTION
# Description
With the recent change to when/how `contractAddress` is returned for `eth_getTransactionReceipt`, we now need to parse the newly created address from events.


## Additional context
Corresponding `zksync-era` PR: https://github.com/matter-labs/zksync-era/pull/3452