### PR TITLE
[Draft] feat: update SDK to expect random account id

### DIFF
--- a/packages/sdk/src/client/passkey/actions/account.ts
+++ b/packages/sdk/src/client/passkey/actions/account.ts
@@ -90,8 +90,7 @@ export const deployAccount = async <
     abi: FactoryAbi,
     functionName: "deployProxySsoAccount",
     args: [
-      toHex(args.salt),
-      accountId,
+      toHex(accountId),
       [encodedPasskeyModuleData, encodedSessionKeyModuleData],
       [],
     ],


### PR DESCRIPTION
[Draft] linked to: https://github.com/matter-labs/zksync-sso-clave-contracts/pull/309
# Description

The ability to front-run an account id was undesirable, so we're removing the ability to read back the account id directly and instead merging it with the deployment salt that determines the account address.

For applications that do need to embed their own account id to perform a non-passkey account lookup, it will be slightly more effort to find the account unique id.

## Additional context

This is 1 of 3 changes breaking the contract ABI, so these other two should merge first before this makes more progress (to avoid merge conficts)

* Multiple passkey support changing the signature [PR](https://github.com/matter-labs/zksync-sso/pull/58)
* Passkey recovery doing a lookup on the passkey module [PR](https://github.com/matter-labs/zksync-sso/pull/72)
* Removing the salt from the account creation  (this change) 

