### PR TITLE
feat: ECDSA client with single owner

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -79,6 +79,11 @@
       "import": "./dist/_esm/client/passkey/index.js",
       "require": "./dist/_cjs/client/passkey/index.js"
     },
+    "./client/ecdsa": {
+      "types": "./dist/_types/client/ecdsa/index.d.ts",
+      "import": "./dist/_esm/client/ecdsa/index.js",
+      "require": "./dist/_cjs/client/ecdsa/index.js"
+    },
     "./client/session": {
       "types": "./dist/_types/client/session/index.d.ts",
       "import": "./dist/_esm/client/session/index.js",

--- a/packages/sdk/src/abi/Factory.ts
+++ b/packages/sdk/src/abi/Factory.ts
@@ -8,12 +8,23 @@ export const FactoryAbi = [
       },
       {
         internalType: "address",
-        name: "_implementation",
+        name: "_beacon",
         type: "address",
       },
     ],
     stateMutability: "nonpayable",
     type: "constructor",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+    ],
+    name: "ACCOUNT_ALREADY_EXISTS",
+    type: "error",
   },
   {
     anonymous: false,
@@ -26,55 +37,36 @@ export const FactoryAbi = [
       },
       {
         indexed: false,
-        internalType: "string",
+        internalType: "bytes32",
         name: "uniqueAccountId",
-        type: "string",
+        type: "bytes32",
       },
     ],
     name: "AccountCreated",
     type: "event",
   },
   {
-    anonymous: false,
     inputs: [
       {
-        indexed: true,
-        internalType: "address",
-        name: "previousOwner",
-        type: "address",
-      },
-      {
-        indexed: true,
-        internalType: "address",
-        name: "newOwner",
-        type: "address",
-      },
-    ],
-    name: "OwnershipTransferred",
-    type: "event",
-  },
-  {
-    anonymous: false,
-    inputs: [
-      {
-        indexed: true,
-        internalType: "address",
-        name: "implementation",
-        type: "address",
-      },
-    ],
-    name: "Upgraded",
-    type: "event",
-  },
-  {
-    inputs: [
-      {
-        internalType: "string",
-        name: "",
-        type: "string",
+        internalType: "bytes32",
+        name: "accountId",
+        type: "bytes32",
       },
     ],
     name: "accountMappings",
+    outputs: [
+      {
+        internalType: "address",
+        name: "deployedAccount",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "beacon",
     outputs: [
       {
         internalType: "address",
@@ -86,25 +78,33 @@ export const FactoryAbi = [
     type: "function",
   },
   {
+    inputs: [],
+    name: "beaconProxyBytecodeHash",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
     inputs: [
       {
         internalType: "bytes32",
-        name: "_salt",
+        name: "uniqueId",
         type: "bytes32",
       },
       {
-        internalType: "string",
-        name: "_uniqueAccountId",
-        type: "string",
-      },
-      {
         internalType: "bytes[]",
-        name: "_initialValidators",
+        name: "initialValidators",
         type: "bytes[]",
       },
       {
         internalType: "address[]",
-        name: "_initialK1Owners",
+        name: "initialK1Owners",
         type: "address[]",
       },
     ],
@@ -121,61 +121,15 @@ export const FactoryAbi = [
   },
   {
     inputs: [],
-    name: "implementation",
+    name: "getEncodedBeacon",
     outputs: [
       {
-        internalType: "address",
+        internalType: "bytes",
         name: "",
-        type: "address",
+        type: "bytes",
       },
     ],
     stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "owner",
-    outputs: [
-      {
-        internalType: "address",
-        name: "",
-        type: "address",
-      },
-    ],
-    stateMutability: "view",
-    type: "function",
-  },
-  {
-    inputs: [],
-    name: "renounceOwnership",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
-        internalType: "address",
-        name: "newOwner",
-        type: "address",
-      },
-    ],
-    name: "transferOwnership",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
-    inputs: [
-      {
-        internalType: "address",
-        name: "newImplementation",
-        type: "address",
-      },
-    ],
-    name: "upgradeTo",
-    outputs: [],
-    stateMutability: "nonpayable",
     type: "function",
   },
 ] as const;

--- a/packages/sdk/src/client/ecdsa/account.ts
+++ b/packages/sdk/src/client/ecdsa/account.ts
@@ -1,0 +1,56 @@
+import type { Address } from "abitype";
+import { type CustomSource, type LocalAccount } from "viem";
+import { toAccount } from "viem/accounts";
+import { serializeTransaction, type ZksyncTransactionSerializableEIP712 } from "viem/zksync";
+
+import { getEip712Domain } from "../utils/getEip712Domain.js";
+import { type Signer, toOwner } from "./types.js";
+
+export type ToEcdsaAccountParameters = {
+  /** Address of the deployed SSO Wallet */
+  address: Address;
+  /** Owner of the EOA */
+  owner: Signer;
+};
+
+export type EcdsaAccount = LocalAccount<"ssoEcdsaAccount"> & {
+  sign: NonNullable<CustomSource["sign"]>;
+};
+
+export async function toEcdsaAccount(
+  parameters: ToEcdsaAccountParameters,
+): Promise<EcdsaAccount> {
+  const { address, owner } = parameters;
+
+  const localOwner = await toOwner({ owner, address });
+
+  const account = toAccount({
+    address,
+    async signMessage({ message }) {
+      return localOwner.signMessage({ message });
+    },
+    async signTransaction(transaction) {
+      const signableTransaction = {
+        ...transaction,
+        from: this.address!,
+        type: "eip712",
+      } as ZksyncTransactionSerializableEIP712;
+
+      const eip712DomainAndMessage = getEip712Domain(signableTransaction);
+      const signature = await localOwner.signTypedData(eip712DomainAndMessage);
+
+      return serializeTransaction({
+        ...signableTransaction,
+        customSignature: signature,
+      });
+    },
+    async signTypedData(typedData) {
+      return localOwner.signTypedData(typedData);
+    },
+  });
+
+  return {
+    ...account,
+    source: "ssoEcdsaAccount",
+  } as EcdsaAccount;
+}

--- a/packages/sdk/src/client/ecdsa/actions/account.ts
+++ b/packages/sdk/src/client/ecdsa/actions/account.ts
@@ -130,8 +130,6 @@ export const fetchAccount = async <
     args: [accountId],
   });
 
-  console.log("accountAddress", accountAddress);
-
   if (!accountAddress || accountAddress == NULL_ADDRESS) throw new Error(`No account found for ID: ${accountId}`);
 
   return {

--- a/packages/sdk/src/client/ecdsa/actions/account.ts
+++ b/packages/sdk/src/client/ecdsa/actions/account.ts
@@ -1,0 +1,141 @@
+import { type Account, type Address, type Chain, type Client, getAddress, type Hash, type Hex, parseAbi, parseEventLogs, type Prettify, toHex, type TransactionReceipt, type Transport } from "viem";
+import { readContract, waitForTransactionReceipt, writeContract } from "viem/actions";
+import { getGeneralPaymasterInput } from "viem/zksync";
+
+import { FactoryAbi } from "../../../abi/Factory.js";
+import { type CustomPaymasterHandler } from "../../../paymaster/index.js";
+import { encodeModuleData, encodeSession } from "../../../utils/encoding.js";
+import { noThrow } from "../../../utils/helpers.js";
+import type { SessionConfig } from "../../../utils/session.js";
+
+export type DeployAccountArgs = {
+  owner: Address; // Wallet owner
+  contracts: {
+    accountFactory: Address;
+    session: Address;
+  };
+  initialSession?: SessionConfig;
+  salt?: Uint8Array; // Random 32 bytes
+  prefix?: string; // vendor prefix
+  onTransactionSent?: (hash: Hash) => void;
+  paymasterHandler?: CustomPaymasterHandler;
+  paymaster?: {
+    address: Address;
+    paymasterInput?: Hex;
+  };
+};
+
+export type DeployAccountReturnType = {
+  address: Address;
+  transactionReceipt: TransactionReceipt;
+};
+
+export type FetchAccountArgs = {
+  prefix?: string; // vendor prefix
+  owner: Address; // Wallet owner
+  contracts: {
+    accountFactory: Address;
+    session: Address;
+  };
+};
+
+export type FetchAccountReturnType = {
+  address: Address;
+  owner: Address;
+};
+
+const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+export const deployAccount = async <
+  transport extends Transport,
+  chain extends Chain,
+  account extends Account,
+>(
+  client: Client<transport, chain, account>, // Account deployer (any viem client)
+  args: Prettify<DeployAccountArgs>,
+): Promise<DeployAccountReturnType> => {
+  if (!args.salt) {
+    args.salt = crypto.getRandomValues(new Uint8Array(32));
+  }
+
+  const accountId = args.prefix ? `${args.prefix}-${args.owner}` : args.owner;
+
+  const encodedSessionKeyModuleData = encodeModuleData({
+    address: args.contracts.session,
+    parameters: args.initialSession ? encodeSession(args.initialSession) : "0x",
+  });
+
+  let deployProxyArgs = {
+    account: client.account!,
+    chain: client.chain!,
+    address: args.contracts.accountFactory,
+    abi: FactoryAbi,
+    functionName: "deployProxySsoAccount",
+    args: [
+      toHex(args.salt),
+      accountId,
+      [encodedSessionKeyModuleData],
+      [args.owner],
+    ],
+  } as any;
+
+  if (args.paymaster) {
+    deployProxyArgs = {
+      ...deployProxyArgs,
+      paymaster: args.paymaster.address,
+      paymasterInput: args.paymaster.paymasterInput ?? getGeneralPaymasterInput({ innerInput: "0x" }),
+    };
+  }
+
+  const transactionHash = await writeContract(client, deployProxyArgs);
+  if (args.onTransactionSent) {
+    noThrow(() => args.onTransactionSent?.(transactionHash));
+  }
+
+  const transactionReceipt = await waitForTransactionReceipt(client, { hash: transactionHash });
+  if (transactionReceipt.status !== "success") throw new Error("Account deployment transaction reverted");
+
+  const accountCreatedEvent = parseEventLogs({ abi: FactoryAbi, logs: transactionReceipt.logs })
+    .find((log) => log && log.eventName === "AccountCreated");
+
+  if (!accountCreatedEvent) {
+    throw new Error("No contract address in transaction receipt");
+  }
+
+  const { accountAddress } = accountCreatedEvent.args;
+
+  return {
+    address: getAddress(accountAddress),
+    transactionReceipt: transactionReceipt,
+  };
+};
+
+export const fetchAccount = async <
+  transport extends Transport,
+  chain extends Chain,
+  account extends Account,
+>(
+  client: Client<transport, chain, account>, // Account deployer (any viem client)
+  args: Prettify<FetchAccountArgs>,
+): Promise<FetchAccountReturnType> => {
+  if (!args.contracts.accountFactory) throw new Error("Account factory address is not set");
+
+  const accountId = args.prefix ? `${args.prefix}-${args.owner}` : args.owner;
+  if (!accountId) throw new Error("No account ID provided");
+
+  const accountAddress = await readContract(client, {
+    abi: parseAbi(["function accountMappings(string) view returns (address)"]),
+    address: args.contracts.accountFactory,
+    functionName: "accountMappings",
+    args: [accountId],
+  });
+
+  console.log("accountAddress", accountAddress);
+
+  if (!accountAddress || accountAddress == NULL_ADDRESS) throw new Error(`No account found for ID: ${accountId}`);
+
+  return {
+    address: accountAddress,
+    owner: args.owner,
+  };
+};

--- a/packages/sdk/src/client/ecdsa/client.ts
+++ b/packages/sdk/src/client/ecdsa/client.ts
@@ -1,0 +1,90 @@
+import { type Account, type Address, type Chain, type Client, createClient, getAddress, type Prettify, type PublicActions, publicActions, type PublicRpcSchema, type RpcSchema, type Transport, type WalletActions, walletActions, type WalletClientConfig, type WalletRpcSchema } from "viem";
+import { eip712WalletActions } from "viem/zksync";
+
+import type { CustomPaymasterHandler } from "../../paymaster/index.js";
+import { toEcdsaAccount } from "./account.js";
+import { type ZksyncSsoEcdsaActions, zksyncSsoEcdsaActions } from "./decorators/ecdsa.js";
+import { zksyncSsoEcdsaWalletActions } from "./decorators/wallet.js";
+import type { Signer } from "./types.js";
+
+export async function createZksyncEcdsaClient<
+  transport extends Transport,
+  chain extends Chain,
+  rpcSchema extends RpcSchema | undefined = undefined,
+>(_parameters: ZksyncSsoEcdsaClientConfig<transport, chain, rpcSchema>): Promise<ZksyncSsoEcdsaClient<transport, chain, rpcSchema>> {
+  type WalletClientParameters = typeof _parameters;
+  const parameters: WalletClientParameters & {
+    key: NonNullable<WalletClientParameters["key"]>;
+    name: NonNullable<WalletClientParameters["name"]>;
+  } = {
+    ..._parameters,
+    address: getAddress(_parameters.address),
+    key: _parameters.key || "zksync-sso-ecdsa-wallet",
+    name: _parameters.name || "ZKsync SSO ECDSA Client",
+  };
+
+  const account = await toEcdsaAccount({
+    address: parameters.address,
+    owner: parameters.owner,
+  });
+
+  const client = createClient<transport, chain, Account, rpcSchema>({
+    ...parameters,
+    account,
+    type: "walletClient",
+  })
+    .extend(() => ({
+      contracts: parameters.contracts,
+    }))
+    .extend(publicActions)
+    .extend(walletActions)
+    .extend(eip712WalletActions())
+    .extend(zksyncSsoEcdsaWalletActions)
+    .extend(zksyncSsoEcdsaActions);
+  return client;
+}
+
+export type EcdsaRequiredContracts = {
+  session: Address; // Session, spend limit, etc.
+  accountFactory?: Address; // For account creation
+};
+
+type ZksyncSsoEcdsaData = {
+  contracts: EcdsaRequiredContracts;
+  paymasterHandler?: CustomPaymasterHandler;
+};
+
+export type ClientWithZksyncSsoEcdsaData<
+  transport extends Transport = Transport,
+  chain extends Chain = Chain,
+> = Client<transport, chain, Account> & ZksyncSsoEcdsaData;
+
+export type ZksyncSsoEcdsaClient<
+  transport extends Transport = Transport,
+  chain extends Chain = Chain,
+  rpcSchema extends RpcSchema | undefined = undefined,
+  account extends Account = Account,
+> = Prettify<
+  Client<
+    transport,
+    chain,
+    account,
+    rpcSchema extends RpcSchema
+      ? [...PublicRpcSchema, ...WalletRpcSchema, ...rpcSchema]
+      : [...PublicRpcSchema, ...WalletRpcSchema],
+    PublicActions<transport, chain, account> & WalletActions<chain, account> & ZksyncSsoEcdsaActions
+  > & ZksyncSsoEcdsaData
+>;
+
+export interface ZksyncSsoEcdsaClientConfig<
+  transport extends Transport = Transport,
+  chain extends Chain = Chain,
+  rpcSchema extends RpcSchema | undefined = undefined,
+> extends Omit<WalletClientConfig<transport, chain, Account, rpcSchema>, "account"> {
+  chain: NonNullable<chain>;
+  address: Address;
+  owner: Signer;
+  contracts: EcdsaRequiredContracts;
+  key?: string;
+  name?: string;
+}

--- a/packages/sdk/src/client/ecdsa/decorators/ecdsa.ts
+++ b/packages/sdk/src/client/ecdsa/decorators/ecdsa.ts
@@ -1,0 +1,32 @@
+import { type Chain, type Transport } from "viem";
+
+import {
+  createSession, type CreateSessionArgs, type CreateSessionReturnType,
+  revokeSession, type RevokeSessionArgs, type RevokeSessionReturnType,
+} from "../../session/actions/session.js";
+import type { ClientWithZksyncSsoEcdsaData } from "../client.js";
+
+export type ZksyncSsoEcdsaActions = {
+  createSession: (args: Omit<CreateSessionArgs, "contracts">) => Promise<CreateSessionReturnType>;
+  revokeSession: (args: Omit<RevokeSessionArgs, "contracts">) => Promise<RevokeSessionReturnType>;
+};
+
+export const zksyncSsoEcdsaActions = <
+  transport extends Transport = Transport,
+  chain extends Chain = Chain,
+>(client: ClientWithZksyncSsoEcdsaData<transport, chain>) => {
+  return {
+    createSession: async (args: Omit<CreateSessionArgs, "contracts">) => {
+      return await createSession(client, {
+        ...args,
+        contracts: client.contracts,
+      });
+    },
+    revokeSession: async (args: Omit<RevokeSessionArgs, "contracts">) => {
+      return await revokeSession(client, {
+        ...args,
+        contracts: client.contracts,
+      });
+    },
+  };
+};

--- a/packages/sdk/src/client/ecdsa/decorators/wallet.ts
+++ b/packages/sdk/src/client/ecdsa/decorators/wallet.ts
@@ -1,0 +1,73 @@
+import { type Account, bytesToHex, type Chain, type ExactPartial, formatTransaction, type RpcTransaction, type Transport, type WalletActions } from "viem";
+import { deployContract, getAddresses, getChainId, sendRawTransaction, signMessage, signTypedData, writeContract } from "viem/actions";
+import { signTransaction, type TransactionRequestEIP712, type ZksyncEip712Meta } from "viem/zksync";
+
+import { getTransactionWithPaymasterData } from "../../../paymaster/index.js";
+import { sendEip712Transaction } from "../../session/actions/sendEip712Transaction.js";
+import type { ClientWithZksyncSsoEcdsaData } from "../client.js";
+
+export type ZksyncSsoEcdsaWalletActions<chain extends Chain, account extends Account> = Omit<
+  WalletActions<chain, account>, "addChain" | "getPermissions" | "requestAddresses" | "requestPermissions" | "switchChain" | "watchAsset" | "prepareTransactionRequest"
+>;
+
+export function zksyncSsoEcdsaWalletActions<
+  transport extends Transport,
+  chain extends Chain,
+  account extends Account,
+>(client: ClientWithZksyncSsoEcdsaData<transport, chain>): ZksyncSsoEcdsaWalletActions<chain, account> {
+  return {
+    deployContract: (args) => deployContract(client, args),
+    getAddresses: () => getAddresses(client),
+    getChainId: () => getChainId(client),
+    sendRawTransaction: (args) => sendRawTransaction(client, args),
+    sendTransaction: async (args) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const unformattedTx: any = Object.assign({}, args);
+
+      if ("eip712Meta" in unformattedTx) {
+        const eip712Meta = unformattedTx.eip712Meta as ZksyncEip712Meta;
+        unformattedTx.gasPerPubdata = eip712Meta.gasPerPubdata ? BigInt(eip712Meta.gasPerPubdata) : undefined;
+        unformattedTx.factoryDeps = eip712Meta.factoryDeps;
+        unformattedTx.customSignature = eip712Meta.customSignature;
+        unformattedTx.paymaster = eip712Meta.paymasterParams?.paymaster;
+        unformattedTx.paymasterInput = eip712Meta.paymasterParams?.paymasterInput ? bytesToHex(new Uint8Array(eip712Meta.paymasterParams?.paymasterInput)) : undefined;
+        delete unformattedTx.eip712Meta;
+      }
+
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      const { chainId: _, ...unformattedTxWithPaymaster } = await getTransactionWithPaymasterData(
+        client.chain.id,
+        client.account.address,
+        unformattedTx,
+        client.paymasterHandler,
+      );
+
+      const formatters = client.chain?.formatters;
+      const format = formatters?.transaction?.format || formatTransaction;
+
+      const tx = {
+        ...format(unformattedTxWithPaymaster as ExactPartial<RpcTransaction>),
+        type: "eip712",
+      };
+
+      return await sendEip712Transaction(client, tx);
+    },
+    signMessage: (args) => signMessage(client, args),
+
+    signTransaction: async (args) => {
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      const { chainId: _, ...unformattedTxWithPaymaster } = await getTransactionWithPaymasterData(
+        client.chain.id,
+        client.account.address,
+        args as TransactionRequestEIP712,
+        client.paymasterHandler,
+      );
+      return signTransaction(client, {
+        ...args,
+        unformattedTxWithPaymaster,
+      } as any);
+    },
+    signTypedData: (args) => signTypedData(client, args),
+    writeContract: (args) => writeContract(client, args),
+  };
+}

--- a/packages/sdk/src/client/ecdsa/index.ts
+++ b/packages/sdk/src/client/ecdsa/index.ts
@@ -1,0 +1,6 @@
+export * from "./account.js";
+export * from "./actions/account.js";
+export * from "./client.js";
+export * from "./decorators/ecdsa.js";
+export * from "./decorators/wallet.js";
+export * from "./types.js";

--- a/packages/sdk/src/client/ecdsa/types.ts
+++ b/packages/sdk/src/client/ecdsa/types.ts
@@ -1,0 +1,92 @@
+import {
+  type Account,
+  type Address,
+  type Chain,
+  createWalletClient, custom,
+  type EIP1193Provider,
+  type LocalAccount,
+  type OneOf,
+  type Transport,
+  type WalletClient } from "viem";
+import { toAccount } from "viem/accounts";
+import { signTypedData } from "viem/actions";
+import { getAction } from "viem/utils";
+
+export type Signer = OneOf<
+  | EIP1193Provider
+  | WalletClient<Transport, Chain | undefined, Account>
+  | LocalAccount
+>;
+
+export type EthereumProvider = OneOf<
+  { request(...args: any): Promise<any> } | EIP1193Provider
+>;
+
+export async function toOwner<provider extends EthereumProvider>({
+  owner,
+  address,
+}: {
+  owner: OneOf<
+    | provider
+    | WalletClient<Transport, Chain | undefined, Account>
+    | LocalAccount
+  >;
+  address?: Address;
+}): Promise<LocalAccount> {
+  if ("type" in owner && owner.type === "local") {
+    return owner as LocalAccount;
+  }
+
+  let walletClient:
+    | WalletClient<Transport, Chain | undefined, Account>
+    | undefined = undefined;
+
+  if ("request" in owner) {
+    if (!address) {
+      try {
+        ;[address] = await (owner as EthereumProvider).request({
+          method: "eth_requestAccounts",
+        });
+      } catch {
+        ;[address] = await (owner as EthereumProvider).request({
+          method: "eth_accounts",
+        });
+      }
+    }
+    if (!address) {
+      // For TS to be happy
+      throw new Error("address is required");
+    }
+    walletClient = createWalletClient({
+      account: address,
+      transport: custom(owner as EthereumProvider),
+    });
+  }
+
+  if (!walletClient) {
+    walletClient = owner as WalletClient<
+      Transport,
+          Chain | undefined,
+          Account
+    >;
+  }
+
+  return toAccount({
+    address: walletClient.account.address,
+    async signMessage({ message }) {
+      return walletClient.signMessage({ message });
+    },
+    async signTypedData(typedData) {
+      return getAction(
+        walletClient,
+        signTypedData,
+        "signTypedData",
+      )(typedData as any);
+    },
+    async signTransaction() {
+      throw new Error(
+        "Smart account signer doesn't need to sign transactions",
+      );
+    },
+  });
+}

--- a/packages/sdk/src/client/index.ts
+++ b/packages/sdk/src/client/index.ts
@@ -1,2 +1,3 @@
+export { deployAccount as deployEcdsaAccount, fetchAccount as fetchEcdsaAccount } from "./ecdsa/actions/account.js";
 export { deployAccount, fetchAccount } from "./passkey/actions/account.js";
 export * from "./session/client.js";


### PR DESCRIPTION
# Description
Added ECDSA client with single owner.

This client allows to deploy a wallet, with a session key validator, managed by an EOA (private key or injected wallet).

### Deploying wallet

FetchAccount and DeployAccount functions access 3 parameters:
- contacts - addresses of contracts
- prefix - unique account id is `${prefix}-${owner}`, so that wallets deployed by different zksync-sso integrators would not conflict with each other
- address - address of owner (EOA)

```typescript
import { createZksyncEcdsaClient, deployAccount, fetchAccount } from "zksync-sso/client/ecdsa";

const richClient = createWalletClient({
  account: privateKeyToAccount("0xprivateKey"),
  chain: chain, // sepolia
  transport: http(),
});

const contracts = { // sepolia
  session: "0x64Bf5C3229CafF50e39Ec58C4BFBbE67bEA90B0F",
  passkey: "0x0F65cFE984d494DAa7165863f1Eb61C606e45fFb",
  accountFactory: "0x73CFa70318FD25F2166d47Af9d93Cf72eED48724",
};

let deployedAccount: any;

try {
  deployedAccount = await fetchAccount(richClient, {
    contracts,
    prefix: "zyfai",
    owner: richClient.account.address,
  });
} catch (err) {
  deployedAccount = await deployAccount(richClient, {
    contracts,
    prefix: "zyfai",
    owner: richClient.account.address,
  });
}
```

### Creating session

createZksyncEcdsaClient also accepts 3 new parameters:
- address - address of the deployed wallet
- owner - injected wallet or an account that owns the SSO wallet
- contracts - addresses of contracts

```ts
const ecdsaClient = await createZksyncEcdsaClient({
  address: deployedAccount.address,
  owner: richClient.account,
  contracts,
  chain: chain,
  transport: http(),
});

const session = await ecdsaClient.createSession({
  sessionConfig: { /** session config */ }
});
```

## Additional context

Tested on locally and on sepolia:

SSO wallet: https://sepolia.explorer.zksync.io/address/0x24ecAfba095d1Af9a57D4e853e5dC6BfbCA3ccdD
Create session tx: https://sepolia.explorer.zksync.io/tx/0xe0d2c575e9bc3388a1525db74e319d80478fd1adfd5bce130530a24e3c138ba8
and then sent a tx using session keys: https://sepolia.explorer.zksync.io/tx/0x54696fe9b020bd9f725f2430162fb45bbc5f13ddb40fdd9516d175c5e6434b38
