### PR TITLE
chore: use upstream alloy-zksync

### DIFF
--- a/packages/sdk-platforms/rust/zksync-sso/Cargo.toml
+++ b/packages/sdk-platforms/rust/zksync-sso/Cargo.toml
@@ -20,7 +20,7 @@ alloy = { version = "0.11.0", default-features = false, features = [
     "contract",
     "eip712",
 ] }
-alloy-zksync = { git = "https://github.com/jackpooleyml/alloy-zksync", rev = "e96bb14e3ca6c3a8031e59494cf05fcedd12f07a" }
+alloy-zksync = { version = "0.11.0" }
 
 # Http
 url = "2.5.4"


### PR DESCRIPTION
# Description

In the previous Swift [PR](https://github.com/matter-labs/zksync-sso/pull/92#issue-2917105516), I mentioned that: 
> This PR also depends on forks of [alloy-zksync](https://github.com/popzxc/alloy-zksync) [...] requires some APIs that are [not yet public](https://github.com/jackpooleyml/alloy-zksync/commit/e96bb14e3ca6c3a8031e59494cf05fcedd12f07a).

[As suggested](https://github.com/popzxc/alloy-zksync/pull/56#pullrequestreview-2689854539) by @popzxc this PR uses different traits to encode the raw transaction thus obviating the need to depend on a fork. 