### PR TITLE
feat: use latest anvil version

### DIFF
--- a/.github/workflows/deploy-auth-server.yml
+++ b/.github/workflows/deploy-auth-server.yml
@@ -43,8 +43,6 @@ jobs:
       # Local node to have target for deploy
       - name: Era Test Node Action
         uses: dutterbutter/anvil-zksync-action@v1.1.0
-        with:
-          releaseTag: 'v0.6.1'
 
       - name: Deploy contracts
         run: pnpm run deploy --file ../auth-server/stores/local-node.json

--- a/.github/workflows/deploy-nft-quest.yml
+++ b/.github/workflows/deploy-nft-quest.yml
@@ -46,8 +46,6 @@ jobs:
       # Local node to have target for deploy
       - name: Era Test Node Action
         uses: dutterbutter/anvil-zksync-action@v1.1.0
-        with:
-          releaseTag: 'v0.6.1'
 
       - name: Deploy contracts
         run: pnpm run deploy --file ../auth-server/stores/local-node.json

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -43,8 +43,6 @@ jobs:
       # Local node to have target for deploy
       - name: Era Test Node Action
         uses: dutterbutter/anvil-zksync-action@v1.1.0
-        with:
-          releaseTag: 'v0.6.1'
 
       - name: Deploy contracts
         run: pnpm run deploy --file ../auth-server/stores/local-node.json

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -44,8 +44,6 @@ jobs:
       # Local node to have target for deploy
       - name: Era Test Node Action
         uses: dutterbutter/anvil-zksync-action@v1.1.0
-        with:
-          releaseTag: 'v0.6.1'
 
       - name: Deploy contracts
         run: pnpm run deploy --file ../auth-server/stores/local-node.json

--- a/.github/workflows/scripts/install-anvil-zksync.sh
+++ b/.github/workflows/scripts/install-anvil-zksync.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 REPO_URL="https://github.com/matter-labs/anvil-zksync.git"
-RELEASE_VERSION="v0.6.1"
+RELEASE_VERSION="v0.6.3"
 RELEASE_FILE_NAME="anvil-zksync-${RELEASE_VERSION}-aarch64-apple-darwin.tar.gz"
 RELEASE_URL="https://github.com/matter-labs/anvil-zksync/releases/download/${RELEASE_VERSION}/${RELEASE_FILE_NAME}"
 INSTALL_DIR="/usr/local/bin"


### PR DESCRIPTION
# Description

Remove the pinning of anvil during CI

## Additional context

This failed with 0.6.2, but was fixed in 0.6.3

It's probably helpful to keep the floating version so we're an early adopter and can report issues