### PR TITLE
fix: incorrect skipPreTransactionStateValidation flag verification

### DIFF
--- a/packages/sdk/src/client/session/decorators/wallet.ts
+++ b/packages/sdk/src/client/session/decorators/wallet.ts
@@ -89,7 +89,7 @@ export function zksyncSsoWalletActions<
         type: "eip712",
       };
 
-      if (client.skipPreTransactionStateValidation !== false) {
+      if (client.skipPreTransactionStateValidation !== true) {
         // Get current session state and trigger callback if needed
         const sessionState = await getSessionStateAndNotify(client);
 


### PR DESCRIPTION
# Description
`if (client.skipPreTransactionStateValidation !== true) {`
Should be `true` instead of `false`