### PR TITLE
feat(chore): adding optional credentials parameter so passkey signing can skip passkey dialog

### DIFF
--- a/packages/sdk/src/client/passkey/actions/passkey.ts
+++ b/packages/sdk/src/client/passkey/actions/passkey.ts
@@ -1,4 +1,4 @@
-import { startAuthentication, startRegistration } from "@simplewebauthn/browser";
+import { type PublicKeyCredentialDescriptorJSON, startAuthentication, startRegistration } from "@simplewebauthn/browser";
 import type { AuthenticationResponseJSON, GenerateAuthenticationOptionsOpts, GenerateRegistrationOptionsOpts, PublicKeyCredentialCreationOptionsJSON, PublicKeyCredentialRequestOptionsJSON, RegistrationResponseJSON, VerifiedRegistrationResponse } from "@simplewebauthn/server";
 import { generateAuthenticationOptions, generateRegistrationOptions, verifyAuthenticationResponse, verifyRegistrationResponse } from "@simplewebauthn/server";
 import type { Account, Address, Chain, Client, Hash, Hex, TransactionReceipt, Transport } from "viem";
@@ -115,6 +115,7 @@ export const registerNewPasskey = async (args: RegisterNewPasskeyArgs): Promise<
 export type RequestPasskeyAuthenticationArgs = {
   challenge: Hash; // Transaction hash to sign
   credentialPublicKey: Uint8Array;
+  credential?: PublicKeyCredentialDescriptorJSON;
   rpID?: string;
   origin?: string;
 };
@@ -127,7 +128,7 @@ export const requestPasskeyAuthentication = async (args: RequestPasskeyAuthentic
     challenge: toBytes(args.challenge),
   });
   const optionsJSON: PublicKeyCredentialRequestOptionsJSON = { ...passkeyAuthenticationOptions };
-  const authenticationResponse: AuthenticationResponseJSON = await startAuthentication({ optionsJSON: optionsJSON });
+  const authenticationResponse: AuthenticationResponseJSON = await startAuthentication({ optionsJSON: { ...optionsJSON, allowCredentials: args.credential ? [args.credential] : [] } });
 
   let { rpID, origin } = identifyPasskeyParams();
   rpID = args.rpID || passkeyAuthenticationOptions.rpId || rpID;

--- a/packages/sdk/src/client/passkey/client.ts
+++ b/packages/sdk/src/client/passkey/client.ts
@@ -1,3 +1,4 @@
+import { type PublicKeyCredentialDescriptorJSON } from "@simplewebauthn/browser";
 import { type Account, type Address, type Chain, type Client, createClient, getAddress, type Prettify, type PublicActions, publicActions, type PublicRpcSchema, type RpcSchema, type Transport, type WalletActions, walletActions, type WalletClientConfig, type WalletRpcSchema } from "viem";
 import { erc7739Actions } from "viem/experimental";
 import { eip712WalletActions } from "viem/zksync";
@@ -34,6 +35,7 @@ export function createZksyncPasskeyClient<
       const passkeySignature = await requestPasskeyAuthentication({
         challenge: hash,
         credentialPublicKey: parameters.credentialPublicKey,
+        credential: parameters.credential,
       });
 
       return passkeyHashSignatureResponseFormat(
@@ -114,6 +116,7 @@ export interface ZksyncSsoPasskeyClientConfig<
   userName: string;
   userDisplayName: string;
   contracts: PasskeyRequiredContracts;
+  credential?: PublicKeyCredentialDescriptorJSON;
   key?: string;
   name?: string;
 }


### PR DESCRIPTION
# Description

Adds an additional parameter to passkey authentican flow, allowing developer to pass a credentials object (stored from the passkey registration), in order for passkey signing to not require the passkey selection dialog to be shown to user.


## Additional context

Highly improves signing UX with passkeys