### PR TITLE
feat: only build and push where permissions are

### DIFF
--- a/.github/workflows/push-oidc-containers.yml
+++ b/.github/workflows/push-oidc-containers.yml
@@ -42,8 +42,6 @@ jobs:
             echo "tag=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "tag=none" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "tag=manual-${{ steps.git_sha.outputs.sha_short }}-${ts}" >> $GITHUB_OUTPUT
           else
             echo "Unsupported event ${GITHUB_EVENT_NAME} or ref ${GITHUB_REF}, only refs/heads/, refs/tags/, pull_request, and workflow_dispatch are supported."
             exit 1


### PR DESCRIPTION
# Description

Added rules to push OIDC containers to only run when on the matter-labs sso repo where docker has permissions.

Also allow manually running this in case the name updates and the permissions remain.


## Additional context

This is blocking sophon from forking and contributing.
See: https://github.com/matter-labs/zksync-sso/actions/runs/17378752504/job/49689219041?pr=178