### PR TITLE
feat: install oidc module by default

### DIFF
--- a/packages/auth-server/composables/useAccountCreate.ts
+++ b/packages/auth-server/composables/useAccountCreate.ts
@@ -55,7 +55,7 @@ export const useAccountCreate = (_chainId: MaybeRef<SupportedChainId>, prividium
         initialSession: sessionData,
       },
       owners: [ownerAddress],
-      installNoDataModules: [chainContracts.recovery],
+      installNoDataModules: [chainContracts.recovery, chainContracts.recoveryOidc],
     });
 
     // Clean up temporary association for Prividium mode


### PR DESCRIPTION

# Description

Add oidc module as default installed

## Additional context

Otherwise it never even attempts to validate because it's not a valid
module! you can configure it even when you aren't a validator
