### PR TITLE
feat: account signer utilities

### DIFF
--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account.rs
@@ -4,6 +4,7 @@ pub mod nonce;
 pub mod send;
 pub mod session;
 pub mod signers;
+pub mod utils;
 
 #[cfg(test)]
 pub mod test_utilities;

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/eoa.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/eoa.rs
@@ -1,9 +1,22 @@
+pub mod active;
+pub mod add;
+pub mod remove;
+
 use crate::erc4337::account::modular_smart_account::signers::STUB_PRIVATE_KEY;
 use alloy::{
     primitives::{Address, Bytes, FixedBytes},
     signers::{SignerSync, local::PrivateKeySigner},
+    sol,
 };
 use std::str::FromStr;
+
+sol!(
+    #[sol(rpc)]
+    #[derive(Debug, Default)]
+    #[allow(missing_docs)]
+    EOAKeyValidator,
+    "../../../../../../packages/erc4337-contracts/out/EOAKeyValidator.sol/EOAKeyValidator.json"
+);
 
 pub fn stub_signature_eoa(eoa_validator: Address) -> eyre::Result<Bytes> {
     let hash = FixedBytes::default();

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/eoa/active.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/eoa/active.rs
@@ -1,0 +1,82 @@
+use crate::{
+    config::contracts::Contracts,
+    erc4337::account::modular_smart_account::{
+        signers::eoa::EOAKeyValidator,
+        utils::{
+            calculate_from_block, create_logs_filter_with_range,
+            parse_add_remove_events,
+        },
+    },
+};
+use alloy::{
+    primitives::Address, providers::Provider, rpc::types::Log,
+    sol_types::SolEvent,
+};
+use std::collections::HashSet;
+
+pub async fn get_active_owners<P>(
+    account_address: Address,
+    provider: P,
+    contracts: Contracts,
+) -> eyre::Result<Vec<Address>>
+where
+    P: Provider + Send + Sync + Clone,
+{
+    let eoa_validator_address = contracts.eoa_validator;
+
+    let from_block = {
+        let current_block = provider.get_block_number().await?;
+        calculate_from_block(current_block)
+    };
+
+    let filter =
+        create_logs_filter_with_range(eoa_validator_address, from_block);
+
+    let all_logs = provider.get_logs(&filter).await?;
+
+    let (added_signers, removed_signers) =
+        parse_eoa_events(all_logs, account_address);
+
+    let active_signers = filter_active_signers(added_signers, removed_signers);
+
+    Ok(active_signers)
+}
+
+fn parse_eoa_events(
+    logs: Vec<Log>,
+    account_address: Address,
+) -> (Vec<Address>, HashSet<Address>) {
+    let owner_added_topic = EOAKeyValidator::OwnerAdded::SIGNATURE_HASH;
+    let owner_removed_topic = EOAKeyValidator::OwnerRemoved::SIGNATURE_HASH;
+
+    parse_add_remove_events(
+        logs,
+        account_address,
+        owner_added_topic,
+        owner_removed_topic,
+        |event: EOAKeyValidator::OwnerAdded, account_address| {
+            if event.smartAccount == account_address {
+                Some(event.owner)
+            } else {
+                None
+            }
+        },
+        |event: EOAKeyValidator::OwnerRemoved, account_address| {
+            if event.smartAccount == account_address {
+                Some(event.owner)
+            } else {
+                None
+            }
+        },
+    )
+}
+
+fn filter_active_signers(
+    added_signers: Vec<Address>,
+    removed_signers: HashSet<Address>,
+) -> Vec<Address> {
+    added_signers
+        .into_iter()
+        .filter(|signer| !removed_signers.contains(signer))
+        .collect()
+}

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/eoa/add.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/eoa/add.rs
@@ -1,0 +1,64 @@
+use crate::erc4337::{
+    account::{
+        erc7579::{Execution, calls::encode_calls},
+        modular_smart_account::{
+            send::{SendParams, send_transaction},
+            signers::eoa::EOAKeyValidator,
+        },
+    },
+    bundler::pimlico::client::BundlerClient,
+    signer::Signer,
+};
+use alloy::{
+    primitives::{Address, Bytes, U256},
+    providers::Provider,
+    sol_types::SolCall,
+};
+
+pub async fn add_owner<P>(
+    account_address: Address,
+    new_owner: Address,
+    entry_point_address: Address,
+    eoa_validator_address: Address,
+    bundler_client: BundlerClient,
+    provider: P,
+    signer: Signer,
+) -> eyre::Result<()>
+where
+    P: Provider + Send + Sync + Clone,
+{
+    let call_data = add_owner_call_data(new_owner, eoa_validator_address);
+
+    send_transaction(SendParams {
+        account: account_address,
+        entry_point: entry_point_address,
+        factory_payload: None,
+        call_data,
+        nonce_key: None,
+        paymaster: None,
+        bundler_client,
+        provider,
+        signer,
+    })
+    .await?;
+
+    Ok(())
+}
+
+fn add_owner_call_data(
+    new_owner: Address,
+    eoa_validator_address: Address,
+) -> Bytes {
+    let add_owner_calldata =
+        EOAKeyValidator::addOwnerCall { owner: new_owner }.abi_encode().into();
+
+    let call = {
+        let target = eoa_validator_address;
+        let value = U256::from(0);
+        let data = add_owner_calldata;
+        Execution { target, value, data }
+    };
+
+    let calls = vec![call];
+    encode_calls(calls).into()
+}

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/eoa/remove.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/eoa/remove.rs
@@ -1,0 +1,246 @@
+use crate::erc4337::{
+    account::{
+        erc7579::{Execution, calls::encode_calls},
+        modular_smart_account::{
+            send::{SendParams, send_transaction},
+            signers::eoa::EOAKeyValidator,
+        },
+    },
+    bundler::pimlico::client::BundlerClient,
+    signer::Signer,
+};
+use alloy::{
+    primitives::{Address, Bytes, U256},
+    providers::Provider,
+    sol_types::SolCall,
+};
+
+pub async fn remove_owner<P>(
+    account_address: Address,
+    owner: Address,
+    entry_point_address: Address,
+    eoa_validator_address: Address,
+    bundler_client: BundlerClient,
+    provider: P,
+    signer: Signer,
+) -> eyre::Result<()>
+where
+    P: Provider + Send + Sync + Clone,
+{
+    let call_data = remove_owner_call_data(owner, eoa_validator_address);
+
+    send_transaction(SendParams {
+        account: account_address,
+        entry_point: entry_point_address,
+        factory_payload: None,
+        call_data,
+        nonce_key: None,
+        paymaster: None,
+        bundler_client,
+        provider,
+        signer,
+    })
+    .await?;
+
+    Ok(())
+}
+
+fn remove_owner_call_data(
+    owner: Address,
+    eoa_validator_address: Address,
+) -> Bytes {
+    let remove_owner_calldata =
+        EOAKeyValidator::removeOwnerCall { owner }.abi_encode().into();
+
+    let call = {
+        let target = eoa_validator_address;
+        let value = U256::from(0);
+        let data = remove_owner_calldata;
+        Execution { target, value, data }
+    };
+
+    let calls = vec![call];
+    encode_calls(calls).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        erc4337::{
+            account::{
+                erc7579::module_installed::is_module_installed,
+                modular_smart_account::{
+                    deploy::{DeployAccountParams, EOASigners, deploy_account},
+                    signers::eoa::{
+                        active::get_active_owners, add::add_owner,
+                        eoa_signature, stub_signature_eoa,
+                    },
+                    test_utilities::fund_account_with_default_amount,
+                },
+            },
+            signer::Signer,
+        },
+        utils::alloy_utilities::test_utilities::{
+            TestInfraConfig,
+            start_anvil_and_deploy_contracts_and_start_bundler_with_config,
+        },
+    };
+    use alloy::primitives::{FixedBytes, address};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_remove_owner() -> eyre::Result<()> {
+        let (
+            _,
+            anvil_instance,
+            provider,
+            contracts,
+            signer_private_key,
+            bundler,
+            bundler_client,
+        ) = {
+            let signer_private_key = "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6".to_string();
+            let config = TestInfraConfig {
+                signer_private_key: signer_private_key.clone(),
+            };
+            start_anvil_and_deploy_contracts_and_start_bundler_with_config(
+                &config,
+            )
+            .await?
+        };
+
+        let entry_point_address =
+            address!("0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108");
+
+        let eoa_validator_address = contracts.eoa_validator;
+        let factory_address = contracts.account_factory;
+
+        let initial_signer =
+            address!("0xa0Ee7A142d267C1f36714E4a8F75612F20a79720");
+        let owner_to_remove =
+            address!("0xb0Ee7A142d267C1f36714E4a8F75612F20a79721");
+
+        let signers = vec![initial_signer];
+
+        let eoa_signers = EOASigners {
+            addresses: signers,
+            validator_address: eoa_validator_address,
+        };
+
+        let account_address = deploy_account(DeployAccountParams {
+            factory_address,
+            eoa_signers: Some(eoa_signers),
+            webauthn_signer: None,
+            id: None,
+            provider: provider.clone(),
+        })
+        .await?;
+
+        println!("Account deployed");
+
+        let is_eoa_module_installed = is_module_installed(
+            eoa_validator_address,
+            account_address,
+            provider.clone(),
+        )
+        .await?;
+
+        eyre::ensure!(is_eoa_module_installed, "eoa_module is not installed");
+
+        fund_account_with_default_amount(account_address, provider.clone())
+            .await?;
+
+        // Add an owner first
+        let signer = {
+            let stub_sig = stub_signature_eoa(eoa_validator_address)?;
+            let signer_private_key = signer_private_key.clone();
+            let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
+                eoa_signature(&signer_private_key, eoa_validator_address, hash)
+            });
+            Signer { provider: signature_provider, stub_signature: stub_sig }
+        };
+
+        add_owner(
+            account_address,
+            owner_to_remove,
+            entry_point_address,
+            eoa_validator_address,
+            bundler_client.clone(),
+            provider.clone(),
+            signer.clone(),
+        )
+        .await?;
+
+        println!("Owner added");
+
+        // Verify owner is added
+        let active_signers_before = get_active_owners(
+            account_address,
+            provider.clone(),
+            contracts.clone(),
+        )
+        .await?;
+
+        println!("Active signers before removal: {:?}", active_signers_before);
+        eyre::ensure!(
+            active_signers_before.contains(&initial_signer),
+            "Initial signer should be active"
+        );
+        eyre::ensure!(
+            active_signers_before.contains(&owner_to_remove),
+            "Owner to remove should be in active signers"
+        );
+        eyre::ensure!(
+            active_signers_before.len() == 2,
+            format!(
+                "Expected 2 active signers, got {}",
+                active_signers_before.len()
+            )
+        );
+
+        // Remove the owner
+        remove_owner(
+            account_address,
+            owner_to_remove,
+            entry_point_address,
+            eoa_validator_address,
+            bundler_client.clone(),
+            provider.clone(),
+            signer,
+        )
+        .await?;
+
+        println!("Owner removed");
+
+        // Verify owner is removed
+        let active_signers_after =
+            get_active_owners(account_address, provider.clone(), contracts)
+                .await?;
+
+        println!("Active signers after removal: {:?}", active_signers_after);
+
+        eyre::ensure!(
+            active_signers_after.contains(&initial_signer),
+            "Initial signer should still be active"
+        );
+        eyre::ensure!(
+            !active_signers_after.contains(&owner_to_remove),
+            "Removed owner should not be in active signers"
+        );
+        eyre::ensure!(
+            active_signers_after.len() == 1,
+            format!(
+                "Expected 1 active signer, got {}",
+                active_signers_after.len()
+            )
+        );
+
+        println!("All assertions passed!");
+
+        drop(anvil_instance);
+        drop(bundler);
+
+        Ok(())
+    }
+}

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/passkey.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/passkey.rs
@@ -1,4 +1,7 @@
+pub mod active;
+pub mod add;
 pub mod encoding;
+pub mod remove;
 
 use crate::erc4337::account::modular_smart_account::signers::{
     STUB_PRIVATE_KEY, eoa::eoa_signature,

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/passkey/active.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/passkey/active.rs
@@ -1,0 +1,102 @@
+use crate::{
+    config::contracts::Contracts,
+    erc4337::account::modular_smart_account::{
+        WebAuthnValidator,
+        utils::{
+            calculate_from_block, create_logs_filter_with_range,
+            parse_add_remove_events,
+        },
+    },
+};
+use alloy::{
+    primitives::{Address, Bytes},
+    providers::Provider,
+    rpc::types::Log,
+    sol_types::SolEvent,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PasskeyDetails {
+    pub credential_id: Bytes,
+    pub domain: String,
+}
+
+pub async fn get_active_passkeys<P>(
+    account_address: Address,
+    provider: P,
+    contracts: Contracts,
+) -> eyre::Result<Vec<PasskeyDetails>>
+where
+    P: Provider + Send + Sync + Clone,
+{
+    let webauthn_validator_address = contracts.webauthn_validator;
+
+    let from_block = {
+        let current_block = provider.get_block_number().await?;
+        calculate_from_block(current_block)
+    };
+
+    let filter =
+        create_logs_filter_with_range(webauthn_validator_address, from_block);
+
+    let all_logs = provider.get_logs(&filter).await?;
+
+    let (created_passkeys, removed_passkeys) =
+        parse_passkey_events(all_logs, account_address);
+
+    let active_passkeys =
+        filter_active_passkeys(created_passkeys, removed_passkeys);
+
+    Ok(active_passkeys)
+}
+
+fn parse_passkey_events(
+    logs: Vec<Log>,
+    account_address: Address,
+) -> (Vec<PasskeyDetails>, HashSet<(Bytes, String)>) {
+    let passkey_created_topic =
+        WebAuthnValidator::PasskeyCreated::SIGNATURE_HASH;
+    let passkey_removed_topic =
+        WebAuthnValidator::PasskeyRemoved::SIGNATURE_HASH;
+
+    parse_add_remove_events(
+        logs,
+        account_address,
+        passkey_created_topic,
+        passkey_removed_topic,
+        |event: WebAuthnValidator::PasskeyCreated, account_address| {
+            if event.keyOwner == account_address {
+                Some(PasskeyDetails {
+                    credential_id: event.credentialId,
+                    domain: event.domain,
+                })
+            } else {
+                None
+            }
+        },
+        |event: WebAuthnValidator::PasskeyRemoved, account_address| {
+            if event.keyOwner == account_address {
+                Some((event.credentialId, event.domain))
+            } else {
+                None
+            }
+        },
+    )
+}
+
+fn filter_active_passkeys(
+    created_passkeys: Vec<PasskeyDetails>,
+    removed_passkeys: HashSet<(Bytes, String)>,
+) -> Vec<PasskeyDetails> {
+    created_passkeys
+        .into_iter()
+        .filter(|passkey| {
+            !removed_passkeys.contains(&(
+                passkey.credential_id.clone(),
+                passkey.domain.clone(),
+            ))
+        })
+        .collect()
+}

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/passkey/add.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/passkey/add.rs
@@ -1,0 +1,74 @@
+use crate::erc4337::{
+    account::{
+        erc7579::{Execution, calls::encode_calls},
+        modular_smart_account::{
+            WebAuthnValidator,
+            add_passkey::PasskeyPayload,
+            send::{SendParams, send_transaction},
+        },
+    },
+    bundler::pimlico::client::BundlerClient,
+    signer::Signer,
+};
+use alloy::{
+    primitives::{Address, Bytes, U256},
+    providers::Provider,
+    sol_types::SolCall,
+};
+
+pub async fn add_passkey<P>(
+    account_address: Address,
+    passkey: PasskeyPayload,
+    entry_point_address: Address,
+    webauthn_validator_address: Address,
+    bundler_client: BundlerClient,
+    provider: P,
+    signer: Signer,
+) -> eyre::Result<()>
+where
+    P: Provider + Send + Sync + Clone,
+{
+    let call_data = add_passkey_call_data(passkey, webauthn_validator_address);
+
+    send_transaction(SendParams {
+        account: account_address,
+        entry_point: entry_point_address,
+        factory_payload: None,
+        call_data,
+        nonce_key: None,
+        paymaster: None,
+        bundler_client,
+        provider,
+        signer,
+    })
+    .await?;
+
+    Ok(())
+}
+
+fn add_passkey_call_data(
+    passkey: PasskeyPayload,
+    webauthn_validator_address: Address,
+) -> Bytes {
+    let credential_id = passkey.credential_id;
+    let origin_domain = passkey.origin_domain;
+    let new_key = passkey.passkey;
+
+    let add_validation_key_calldata = WebAuthnValidator::addValidationKeyCall {
+        credentialId: credential_id,
+        newKey: new_key,
+        domain: origin_domain,
+    }
+    .abi_encode()
+    .into();
+
+    let call = {
+        let target = webauthn_validator_address;
+        let value = U256::from(0);
+        let data = add_validation_key_calldata;
+        Execution { target, value, data }
+    };
+
+    let calls = vec![call];
+    encode_calls(calls).into()
+}

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/passkey/remove.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/passkey/remove.rs
@@ -1,0 +1,357 @@
+use crate::erc4337::{
+    account::{
+        erc7579::{Execution, calls::encode_calls},
+        modular_smart_account::{
+            WebAuthnValidator,
+            send::{SendParams, send_transaction},
+            signers::passkey::active::PasskeyDetails,
+        },
+    },
+    bundler::pimlico::client::BundlerClient,
+    signer::Signer,
+};
+use alloy::{
+    primitives::{Address, Bytes, U256},
+    providers::Provider,
+    sol_types::SolCall,
+};
+
+pub async fn remove_passkey<P>(
+    account_address: Address,
+    passkey: PasskeyDetails,
+    entry_point_address: Address,
+    webauthn_validator_address: Address,
+    bundler_client: BundlerClient,
+    provider: P,
+    signer: Signer,
+) -> eyre::Result<()>
+where
+    P: Provider + Send + Sync + Clone,
+{
+    let call_data =
+        remove_passkey_call_data(passkey, webauthn_validator_address);
+
+    send_transaction(SendParams {
+        account: account_address,
+        entry_point: entry_point_address,
+        factory_payload: None,
+        call_data,
+        nonce_key: None,
+        paymaster: None,
+        bundler_client,
+        provider,
+        signer,
+    })
+    .await?;
+
+    Ok(())
+}
+
+fn remove_passkey_call_data(
+    passkey: PasskeyDetails,
+    webauthn_validator_address: Address,
+) -> Bytes {
+    let credential_id = passkey.credential_id;
+    let domain = passkey.domain;
+
+    let remove_validation_key_calldata =
+        WebAuthnValidator::removeValidationKeyCall {
+            credentialId: credential_id,
+            domain,
+        }
+        .abi_encode()
+        .into();
+
+    let call = {
+        let target = webauthn_validator_address;
+        let value = U256::from(0);
+        let data = remove_validation_key_calldata;
+        Execution { target, value, data }
+    };
+
+    let calls = vec![call];
+    encode_calls(calls).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        erc4337::{
+            account::{
+                erc7579::{
+                    add_module::add_module,
+                    module_installed::is_module_installed,
+                },
+                modular_smart_account::{
+                    add_passkey::PasskeyPayload,
+                    deploy::{DeployAccountParams, EOASigners, deploy_account},
+                    signers::{
+                        eoa::{eoa_signature, stub_signature_eoa},
+                        passkey::{
+                            active::{PasskeyDetails, get_active_passkeys},
+                            add::add_passkey,
+                        },
+                    },
+                    test_utilities::fund_account_with_default_amount,
+                },
+            },
+            signer::Signer,
+        },
+        utils::alloy_utilities::test_utilities::{
+            TestInfraConfig,
+            start_anvil_and_deploy_contracts_and_start_bundler_with_config,
+        },
+    };
+    use alloy::primitives::{FixedBytes, address, bytes, fixed_bytes};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_remove_passkey() -> eyre::Result<()> {
+        let (
+            _,
+            anvil_instance,
+            provider,
+            contracts,
+            signer_private_key,
+            bundler,
+            bundler_client,
+        ) = {
+            let signer_private_key = "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6".to_string();
+            let config = TestInfraConfig {
+                signer_private_key: signer_private_key.clone(),
+            };
+            start_anvil_and_deploy_contracts_and_start_bundler_with_config(
+                &config,
+            )
+            .await?
+        };
+
+        let entry_point_address =
+            address!("0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108");
+
+        let eoa_validator_address = contracts.eoa_validator;
+        let webauthn_validator_address = contracts.webauthn_validator;
+        let factory_address = contracts.account_factory;
+
+        let initial_signer =
+            address!("0xa0Ee7A142d267C1f36714E4a8F75612F20a79720");
+
+        let signers = vec![initial_signer];
+
+        let eoa_signers = EOASigners {
+            addresses: signers,
+            validator_address: eoa_validator_address,
+        };
+
+        let account_address = deploy_account(DeployAccountParams {
+            factory_address,
+            eoa_signers: Some(eoa_signers),
+            webauthn_signer: None,
+            id: None,
+            provider: provider.clone(),
+        })
+        .await?;
+
+        println!("Account deployed");
+
+        let is_eoa_module_installed = is_module_installed(
+            eoa_validator_address,
+            account_address,
+            provider.clone(),
+        )
+        .await?;
+
+        eyre::ensure!(is_eoa_module_installed, "eoa_module is not installed");
+
+        fund_account_with_default_amount(account_address, provider.clone())
+            .await?;
+
+        // Install WebAuthn module
+        let signer = {
+            let stub_sig = stub_signature_eoa(eoa_validator_address)?;
+            let signer_private_key = signer_private_key.clone();
+            let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
+                eoa_signature(&signer_private_key, eoa_validator_address, hash)
+            });
+            Signer { provider: signature_provider, stub_signature: stub_sig }
+        };
+
+        add_module(
+            account_address,
+            webauthn_validator_address,
+            entry_point_address,
+            provider.clone(),
+            bundler_client.clone(),
+            signer.clone(),
+        )
+        .await?;
+
+        let is_webauthn_module_installed = is_module_installed(
+            webauthn_validator_address,
+            account_address,
+            provider.clone(),
+        )
+        .await?;
+
+        eyre::ensure!(
+            is_webauthn_module_installed,
+            "webauthn_module is not installed"
+        );
+
+        // Add a passkey first
+        let credential_id_1 = bytes!("0x2868baa08431052f6c7541392a458f64");
+        let passkey_1 = [
+            fixed_bytes!(
+                "0xe0a43b9c64a2357ea7f66a0551f57442fbd32031162d9be762800864168fae40"
+            ),
+            fixed_bytes!(
+                "0x450875e2c28222e81eb25ae58d095a3e7ca295faa3fc26fb0e558a0b571da501"
+            ),
+        ];
+        let domain_1 = "https://example.com".to_string();
+
+        let passkey_payload_1 = PasskeyPayload {
+            credential_id: credential_id_1.clone(),
+            passkey: passkey_1,
+            origin_domain: domain_1.clone(),
+        };
+
+        add_passkey(
+            account_address,
+            passkey_payload_1,
+            entry_point_address,
+            webauthn_validator_address,
+            bundler_client.clone(),
+            provider.clone(),
+            signer.clone(),
+        )
+        .await?;
+
+        println!("Passkey 1 added");
+
+        // Add a second passkey to verify we can have multiple
+        let credential_id_2 = bytes!("0x3868baa08431052f6c7541392a458f65");
+        let passkey_2 = [
+            fixed_bytes!(
+                "0xf0a43b9c64a2357ea7f66a0551f57442fbd32031162d9be762800864168fae41"
+            ),
+            fixed_bytes!(
+                "0x550875e2c28222e81eb25ae58d095a3e7ca295faa3fc26fb0e558a0b571da502"
+            ),
+        ];
+        let domain_2 = "https://example2.com".to_string();
+
+        let passkey_payload_2 = PasskeyPayload {
+            credential_id: credential_id_2.clone(),
+            passkey: passkey_2,
+            origin_domain: domain_2.clone(),
+        };
+
+        add_passkey(
+            account_address,
+            passkey_payload_2,
+            entry_point_address,
+            webauthn_validator_address,
+            bundler_client.clone(),
+            provider.clone(),
+            signer.clone(),
+        )
+        .await?;
+
+        println!("Passkey 2 added");
+
+        // Verify both passkeys are active
+        let active_passkeys_before = get_active_passkeys(
+            account_address,
+            provider.clone(),
+            contracts.clone(),
+        )
+        .await?;
+
+        println!(
+            "Active passkeys before removal: {:?}",
+            active_passkeys_before
+        );
+        eyre::ensure!(
+            active_passkeys_before.len() == 2,
+            format!(
+                "Expected 2 active passkeys, got {}",
+                active_passkeys_before.len()
+            )
+        );
+
+        let passkey_1_found = active_passkeys_before.iter().any(|p| {
+            p.credential_id == credential_id_1 && p.domain == domain_1
+        });
+        eyre::ensure!(
+            passkey_1_found,
+            "Passkey 1 should be in active passkeys"
+        );
+
+        let passkey_2_found = active_passkeys_before.iter().any(|p| {
+            p.credential_id == credential_id_2 && p.domain == domain_2
+        });
+        eyre::ensure!(
+            passkey_2_found,
+            "Passkey 2 should be in active passkeys"
+        );
+
+        // Remove passkey 1
+        let passkey_to_remove = PasskeyDetails {
+            credential_id: credential_id_1.clone(),
+            domain: domain_1.clone(),
+        };
+
+        remove_passkey(
+            account_address,
+            passkey_to_remove,
+            entry_point_address,
+            webauthn_validator_address,
+            bundler_client.clone(),
+            provider.clone(),
+            signer,
+        )
+        .await?;
+
+        println!("Passkey 1 removed");
+
+        // Verify passkey 1 is removed but passkey 2 is still active
+        let active_passkeys_after =
+            get_active_passkeys(account_address, provider.clone(), contracts)
+                .await?;
+
+        println!("Active passkeys after removal: {:?}", active_passkeys_after);
+
+        let passkey_1_still_active = active_passkeys_after.iter().any(|p| {
+            p.credential_id == credential_id_1 && p.domain == domain_1
+        });
+        eyre::ensure!(
+            !passkey_1_still_active,
+            "Removed passkey 1 should not be in active passkeys"
+        );
+
+        let passkey_2_still_active = active_passkeys_after.iter().any(|p| {
+            p.credential_id == credential_id_2 && p.domain == domain_2
+        });
+        eyre::ensure!(
+            passkey_2_still_active,
+            "Passkey 2 should still be active"
+        );
+
+        eyre::ensure!(
+            active_passkeys_after.len() == 1,
+            format!(
+                "Expected 1 active passkey, got {}",
+                active_passkeys_after.len()
+            )
+        );
+
+        println!("All assertions passed!");
+
+        drop(anvil_instance);
+        drop(bundler);
+
+        Ok(())
+    }
+}

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/utils.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/utils.rs
@@ -1,0 +1,70 @@
+use alloy::{
+    primitives::Address,
+    rpc::types::{BlockNumberOrTag, Filter, FilterSet, Log},
+    sol_types::SolEvent,
+};
+use std::collections::HashSet;
+
+pub const MAX_BLOCK_RANGE: u64 = 100_000;
+
+pub fn calculate_from_block(current_block: u64) -> u64 {
+    current_block.saturating_sub(MAX_BLOCK_RANGE)
+}
+
+pub fn create_logs_filter_with_range(
+    contract_address: Address,
+    from_block: u64,
+) -> Filter {
+    Filter {
+        address: contract_address.into(),
+        topics: [
+            FilterSet::default(),
+            FilterSet::default(),
+            FilterSet::default(),
+            FilterSet::default(),
+        ],
+        block_option: alloy::rpc::types::FilterBlockOption::Range {
+            from_block: Some(BlockNumberOrTag::Number(from_block)),
+            to_block: None,
+        },
+    }
+}
+
+pub fn parse_add_remove_events<AddItem, RemoveKey, AddEvent, RemoveEvent>(
+    logs: Vec<Log>,
+    account_address: Address,
+    add_topic: alloy::primitives::FixedBytes<32>,
+    remove_topic: alloy::primitives::FixedBytes<32>,
+    extract_add: impl Fn(AddEvent, Address) -> Option<AddItem>,
+    extract_remove: impl Fn(RemoveEvent, Address) -> Option<RemoveKey>,
+) -> (Vec<AddItem>, HashSet<RemoveKey>)
+where
+    AddEvent: SolEvent,
+    RemoveEvent: SolEvent,
+    RemoveKey: std::hash::Hash + Eq,
+{
+    let mut added_items: Vec<AddItem> = Vec::new();
+    let mut removed_keys: HashSet<RemoveKey> = HashSet::new();
+
+    for log in logs {
+        if let Some(topic0) = log.inner.topics().first() {
+            if *topic0 == add_topic {
+                if let Ok(decoded) = log.log_decode::<AddEvent>() {
+                    let event = decoded.inner.data;
+                    if let Some(item) = extract_add(event, account_address) {
+                        added_items.push(item);
+                    }
+                }
+            } else if *topic0 == remove_topic
+                && let Ok(decoded) = log.log_decode::<RemoveEvent>()
+            {
+                let event = decoded.inner.data;
+                if let Some(key) = extract_remove(event, account_address) {
+                    removed_keys.insert(key);
+                }
+            }
+        }
+    }
+
+    (added_items, removed_keys)
+}


### PR DESCRIPTION
# Description

This adds a number of account signer utilities.

For both both EOA signers and Passkey signers it adds the ability to `add`, `remove`, and `get_active`.
