### PR TITLE
feat: async signer

### DIFF
--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/erc7579/add_module.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/erc7579/add_module.rs
@@ -71,18 +71,19 @@ fn add_module_call_data(
 mod tests {
     use super::*;
     use crate::{
-        erc4337::account::modular_smart_account::{
-            deploy::{DeployAccountParams, EOASigners, deploy_account},
-            signers::eoa::{eoa_signature, stub_signature_eoa},
-            test_utilities::fund_account_with_default_amount,
+        erc4337::{
+            account::modular_smart_account::{
+                deploy::{DeployAccountParams, EOASigners, deploy_account},
+                test_utilities::fund_account_with_default_amount,
+            },
+            signer::create_eoa_signer,
         },
         utils::alloy_utilities::test_utilities::{
             TestInfraConfig,
             start_anvil_and_deploy_contracts_and_start_bundler_with_config,
         },
     };
-    use alloy::primitives::{FixedBytes, address};
-    use std::sync::Arc;
+    use alloy::primitives::address;
 
     #[tokio::test]
     async fn test_add_module() -> eyre::Result<()> {
@@ -147,17 +148,10 @@ mod tests {
 
         let module_address = contracts.webauthn_validator;
 
-        let stub_sig = stub_signature_eoa(eoa_validator_address)?;
-
-        let signature_provider = {
-            let signer_private_key = signer_private_key.clone();
-            Arc::new(move |hash: FixedBytes<32>| {
-                eoa_signature(&signer_private_key, eoa_validator_address, hash)
-            })
-        };
-
-        let signer =
-            Signer { provider: signature_provider, stub_signature: stub_sig };
+        let signer = create_eoa_signer(
+            signer_private_key.clone(),
+            eoa_validator_address,
+        )?;
 
         add_module(
             account_address,

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/add_passkey.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/add_passkey.rs
@@ -97,19 +97,17 @@ mod tests {
                 },
                 modular_smart_account::{
                     deploy::{DeployAccountParams, EOASigners, deploy_account},
-                    signers::eoa::{eoa_signature, stub_signature_eoa},
                     test_utilities::fund_account_with_default_amount,
                 },
             },
-            signer::Signer,
+            signer::create_eoa_signer,
         },
         utils::alloy_utilities::test_utilities::{
             TestInfraConfig,
             start_anvil_and_deploy_contracts_and_start_bundler_with_config,
         },
     };
-    use alloy::primitives::{FixedBytes, address, bytes, fixed_bytes};
-    use std::sync::Arc;
+    use alloy::primitives::{address, bytes, fixed_bytes};
 
     #[tokio::test]
     async fn test_add_passkey() -> eyre::Result<()> {
@@ -168,16 +166,10 @@ mod tests {
 
         let webauthn_module = contracts.webauthn_validator;
         {
-            let stub_sig = stub_signature_eoa(eoa_validator_address)?;
-            let signer_private_key = signer_private_key.clone();
-            let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
-                eoa_signature(&signer_private_key, eoa_validator_address, hash)
-            });
-
-            let signer = Signer {
-                provider: signature_provider,
-                stub_signature: stub_sig,
-            };
+            let signer = create_eoa_signer(
+                signer_private_key.clone(),
+                eoa_validator_address,
+            )?;
 
             add_module(
                 address,
@@ -204,22 +196,10 @@ mod tests {
             let passkey =
                 PasskeyPayload { credential_id, passkey, origin_domain };
 
-            let signer = {
-                let stub_sig = stub_signature_eoa(eoa_validator_address)?;
-                let signer_private_key = signer_private_key.clone();
-                let signature_provider =
-                    Arc::new(move |hash: FixedBytes<32>| {
-                        eoa_signature(
-                            &signer_private_key,
-                            eoa_validator_address,
-                            hash,
-                        )
-                    });
-                Signer {
-                    provider: signature_provider,
-                    stub_signature: stub_sig,
-                }
-            };
+            let signer = create_eoa_signer(
+                signer_private_key.clone(),
+                eoa_validator_address,
+            )?;
 
             add_passkey(
                 address,

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/send.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/send.rs
@@ -163,7 +163,7 @@ where
     .await?;
 
     let signature_provider = Arc::clone(&signer.provider);
-    let signature = signature_provider(hash.0)?;
+    let signature = signature_provider(hash.0).await?;
     user_op.signature = signature;
 
     let user_op_hash =

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/send/passkey.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/send/passkey.rs
@@ -38,7 +38,7 @@ where
         signature_provider,
     } = params;
 
-    let stub_sig = signature_provider(FixedBytes::<32>::default())?;
+    let stub_sig = signature_provider(FixedBytes::<32>::default()).await?;
 
     let signer =
         Signer { provider: signature_provider, stub_signature: stub_sig };
@@ -63,17 +63,19 @@ where
 pub mod tests {
     use super::*;
     use crate::{
-        erc4337::account::{
-            erc7579::{
-                Execution, add_module::add_module, calls::encode_calls,
-                module_installed::is_module_installed,
+        erc4337::{
+            account::{
+                erc7579::{
+                    Execution, add_module::add_module, calls::encode_calls,
+                    module_installed::is_module_installed,
+                },
+                modular_smart_account::{
+                    add_passkey::{PasskeyPayload, add_passkey},
+                    deploy::{DeployAccountParams, EOASigners, deploy_account},
+                    test_utilities::fund_account_with_default_amount,
+                },
             },
-            modular_smart_account::{
-                add_passkey::{PasskeyPayload, add_passkey},
-                deploy::{DeployAccountParams, EOASigners, deploy_account},
-                signers::eoa::{eoa_signature, stub_signature_eoa},
-                test_utilities::fund_account_with_default_amount,
-            },
+            signer::{create_eoa_signer, test_utils::get_signature_from_js},
         },
         utils::alloy_utilities::test_utilities::{
             TestInfraConfig,
@@ -84,50 +86,7 @@ pub mod tests {
         primitives::{Bytes, U256, address, bytes, fixed_bytes},
         rpc::types::TransactionRequest,
     };
-    use std::{str::FromStr, sync::Arc};
-
-    pub fn get_signature_from_js(hash: String) -> eyre::Result<Bytes> {
-        use std::process::Command;
-
-        let working_dir = "../../../../../erc4337-contracts";
-
-        let output = Command::new("pnpm")
-            .arg("tsx")
-            .arg("test/integration/utils.ts")
-            .arg("--hash")
-            .arg(&hash)
-            .current_dir(working_dir)
-            .output()?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            eyre::bail!("Failed to sign hash with passkey: {}", stderr);
-        }
-
-        let stdout = String::from_utf8(output.stdout)?;
-        dbg!(&stdout);
-
-        // Extract the last non-empty line which should be the hex signature
-        let last_line = stdout
-            .lines()
-            .filter(|line| !line.is_empty())
-            .next_back()
-            .ok_or_else(|| {
-                eyre::eyre!("No output from sign_hash_with_passkey command")
-            })?;
-        dbg!(&last_line);
-        dbg!(last_line.len());
-
-        let hex_sig = last_line.trim();
-        dbg!(&hex_sig);
-        dbg!(hex_sig.len());
-
-        let bytes = Bytes::from_str(hex_sig)?;
-        dbg!(&bytes);
-        dbg!(&bytes.len());
-
-        Ok(bytes)
-    }
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_send_transaction_webauthn() -> eyre::Result<()> {
@@ -193,14 +152,10 @@ pub mod tests {
 
         let webauthn_module = contracts.webauthn_validator;
 
-        let signer = {
-            let stub_sig = stub_signature_eoa(eoa_validator_address)?;
-            let signer_private_key = signer_private_key.clone();
-            let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
-                eoa_signature(&signer_private_key, eoa_validator_address, hash)
-            });
-            Signer { provider: signature_provider, stub_signature: stub_sig }
-        };
+        let signer = create_eoa_signer(
+            signer_private_key.clone(),
+            eoa_validator_address,
+        )?;
 
         {
             add_module(
@@ -262,8 +217,10 @@ pub mod tests {
 
         let signature_provider: SignatureProvider =
             Arc::new(move |hash: FixedBytes<32>| {
-                let result = get_signature_from_js(hash.to_string())?;
-                Ok(result)
+                Box::pin(async move {
+                    let result = get_signature_from_js(hash.to_string())?;
+                    Ok(result)
+                })
             });
 
         passkey_send_transaction(PasskeySendParams {
@@ -353,14 +310,10 @@ pub mod tests {
 
         let webauthn_module = contracts.webauthn_validator;
 
-        let signer = {
-            let stub_sig = stub_signature_eoa(eoa_validator_address)?;
-            let signer_private_key = signer_private_key.clone();
-            let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
-                eoa_signature(&signer_private_key, eoa_validator_address, hash)
-            });
-            Signer { provider: signature_provider, stub_signature: stub_sig }
-        };
+        let signer = create_eoa_signer(
+            signer_private_key.clone(),
+            eoa_validator_address,
+        )?;
 
         // Install WebAuthn validator
         {

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/session/active.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/session/active.rs
@@ -131,11 +131,10 @@ mod tests {
                             usage_limit::UsageLimit,
                         },
                     },
-                    signers::eoa::{eoa_signature, stub_signature_eoa},
                     test_utilities::fund_account_with_default_amount,
                 },
             },
-            signer::Signer,
+            signer::create_eoa_signer,
         },
         utils::alloy_utilities::test_utilities::{
             TestInfraConfig,
@@ -146,7 +145,7 @@ mod tests {
         primitives::{FixedBytes, U256, Uint, address},
         rpc::types::{BlockNumberOrTag, FilterBlockOption, FilterSet},
     };
-    use std::{collections::HashSet, sync::Arc};
+    use std::collections::HashSet;
 
     fn create_session_logs_filter(
         session_key_validator_address: Address,
@@ -228,16 +227,10 @@ mod tests {
             .await?;
 
         {
-            let stub_sig = stub_signature_eoa(eoa_validator_address)?;
-            let signer_private_key = signer_private_key.clone();
-            let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
-                eoa_signature(&signer_private_key, eoa_validator_address, hash)
-            });
-
-            let signer = Signer {
-                provider: signature_provider,
-                stub_signature: stub_sig,
-            };
+            let signer = create_eoa_signer(
+                signer_private_key.clone(),
+                eoa_validator_address,
+            )?;
 
             add_module(
                 account_address,
@@ -264,14 +257,10 @@ mod tests {
             println!("\n\n\nsession_key_module successfully installed\n\n\n")
         }
 
-        let signer = {
-            let stub_sig = stub_signature_eoa(eoa_validator_address)?;
-            let signer_private_key = signer_private_key.clone();
-            let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
-                eoa_signature(&signer_private_key, eoa_validator_address, hash)
-            });
-            Signer { provider: signature_provider, stub_signature: stub_sig }
-        };
+        let signer = create_eoa_signer(
+            signer_private_key.clone(),
+            eoa_validator_address,
+        )?;
 
         // Create first session (will remain active)
         let session_spec_1 = {

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/session/create.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/session/create.rs
@@ -80,29 +80,26 @@ mod tests {
                         DeployAccountParams, EOASigners, WebAuthNSigner,
                         deploy_account,
                     },
-                    send::passkey::tests::get_signature_from_js,
                     session::session_lib::session_spec::{
                         limit_type::LimitType, transfer_spec::TransferSpec,
                         usage_limit::UsageLimit,
                     },
-                    signers::eoa::{eoa_signature, stub_signature_eoa},
                     test_utilities::fund_account_with_default_amount,
                 },
             },
-            signer::Signer,
+            signer::{
+                create_eoa_signer, test_utils::create_test_webauthn_js_signer,
+            },
         },
         utils::alloy_utilities::test_utilities::{
             TestInfraConfig,
             start_anvil_and_deploy_contracts_and_start_bundler_with_config,
         },
     };
-    use alloy::primitives::{
-        FixedBytes, U256, Uint, address, bytes, fixed_bytes,
-    };
-    use std::sync::Arc;
+    use alloy::primitives::{U256, Uint, address, bytes, fixed_bytes};
 
     #[tokio::test]
-    async fn test_create_session_new() -> eyre::Result<()> {
+    async fn test_create_session() -> eyre::Result<()> {
         let (
             _,
             anvil_instance,
@@ -163,16 +160,10 @@ mod tests {
         fund_account_with_default_amount(address, provider.clone()).await?;
 
         {
-            let stub_sig = stub_signature_eoa(eoa_validator_address)?;
-            let signer_private_key = signer_private_key.clone();
-            let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
-                eoa_signature(&signer_private_key, eoa_validator_address, hash)
-            });
-
-            let signer = Signer {
-                provider: signature_provider,
-                stub_signature: stub_sig,
-            };
+            let signer = create_eoa_signer(
+                signer_private_key.clone(),
+                eoa_validator_address,
+            )?;
 
             add_module(
                 address,
@@ -199,14 +190,10 @@ mod tests {
             println!("\n\n\nsession_key_module successfully installed\n\n\n")
         }
 
-        let signer = {
-            let stub_sig = stub_signature_eoa(eoa_validator_address)?;
-            let signer_private_key = signer_private_key.clone();
-            let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
-                eoa_signature(&signer_private_key, eoa_validator_address, hash)
-            });
-            Signer { provider: signature_provider, stub_signature: stub_sig }
-        };
+        let signer = create_eoa_signer(
+            signer_private_key.clone(),
+            eoa_validator_address,
+        )?;
 
         {
             let signer_address =
@@ -254,7 +241,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_create_session_with_webauthn_new() -> eyre::Result<()> {
+    async fn test_create_session_with_webauthn() -> eyre::Result<()> {
         let (
             _,
             anvil_instance,
@@ -322,17 +309,7 @@ mod tests {
 
         fund_account_with_default_amount(address, provider.clone()).await?;
 
-        let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
-            let result = get_signature_from_js(hash.to_string())?;
-            Ok(result)
-        });
-
-        let signer = Signer {
-            stub_signature: get_signature_from_js(
-                FixedBytes::<32>::default().to_string(),
-            )?,
-            provider: signature_provider,
-        };
+        let signer = create_test_webauthn_js_signer();
 
         {
             add_module(

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/session/revoke.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/session/revoke.rs
@@ -79,7 +79,6 @@ mod tests {
                         DeployAccountParams, EOASigners, WebAuthNSigner,
                         deploy_account,
                     },
-                    send::passkey::tests::get_signature_from_js,
                     session::{
                         create::create_session,
                         hash::hash_session,
@@ -90,11 +89,12 @@ mod tests {
                         },
                         status::get_session_status,
                     },
-                    signers::eoa::{eoa_signature, stub_signature_eoa},
                     test_utilities::fund_account_with_default_amount,
                 },
             },
-            signer::Signer,
+            signer::{
+                create_eoa_signer, test_utils::create_test_webauthn_js_signer,
+            },
         },
         utils::alloy_utilities::test_utilities::{
             TestInfraConfig,
@@ -102,7 +102,6 @@ mod tests {
         },
     };
     use alloy::primitives::{U256, Uint, address, bytes, fixed_bytes};
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_revoke_session() -> eyre::Result<()> {
@@ -165,16 +164,10 @@ mod tests {
         fund_account_with_default_amount(address, provider.clone()).await?;
 
         {
-            let stub_sig = stub_signature_eoa(eoa_validator_address)?;
-            let signer_private_key = signer_private_key.clone();
-            let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
-                eoa_signature(&signer_private_key, eoa_validator_address, hash)
-            });
-
-            let signer = Signer {
-                provider: signature_provider,
-                stub_signature: stub_sig,
-            };
+            let signer = create_eoa_signer(
+                signer_private_key.clone(),
+                eoa_validator_address,
+            )?;
 
             add_module(
                 address,
@@ -201,14 +194,10 @@ mod tests {
             println!("\n\n\nsession_key_module successfully installed\n\n\n")
         }
 
-        let signer = {
-            let stub_sig = stub_signature_eoa(eoa_validator_address)?;
-            let signer_private_key = signer_private_key.clone();
-            let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
-                eoa_signature(&signer_private_key, eoa_validator_address, hash)
-            });
-            Signer { provider: signature_provider, stub_signature: stub_sig }
-        };
+        let signer = create_eoa_signer(
+            signer_private_key.clone(),
+            eoa_validator_address,
+        )?;
 
         let session_spec = {
             let signer_address =
@@ -357,17 +346,7 @@ mod tests {
 
         fund_account_with_default_amount(address, provider.clone()).await?;
 
-        let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
-            let result = get_signature_from_js(hash.to_string())?;
-            Ok(result)
-        });
-
-        let signer = Signer {
-            stub_signature: get_signature_from_js(
-                FixedBytes::<32>::default().to_string(),
-            )?,
-            provider: signature_provider,
-        };
+        let signer = create_test_webauthn_js_signer();
 
         {
             add_module(

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/eoa/remove.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/eoa/remove.rs
@@ -72,22 +72,18 @@ mod tests {
                 erc7579::module_installed::is_module_installed,
                 modular_smart_account::{
                     deploy::{DeployAccountParams, EOASigners, deploy_account},
-                    signers::eoa::{
-                        active::get_active_owners, add::add_owner,
-                        eoa_signature, stub_signature_eoa,
-                    },
+                    signers::eoa::{active::get_active_owners, add::add_owner},
                     test_utilities::fund_account_with_default_amount,
                 },
             },
-            signer::Signer,
+            signer::create_eoa_signer,
         },
         utils::alloy_utilities::test_utilities::{
             TestInfraConfig,
             start_anvil_and_deploy_contracts_and_start_bundler_with_config,
         },
     };
-    use alloy::primitives::{FixedBytes, address};
-    use std::sync::Arc;
+    use alloy::primitives::address;
 
     #[tokio::test]
     async fn test_remove_owner() -> eyre::Result<()> {
@@ -152,14 +148,10 @@ mod tests {
             .await?;
 
         // Add an owner first
-        let signer = {
-            let stub_sig = stub_signature_eoa(eoa_validator_address)?;
-            let signer_private_key = signer_private_key.clone();
-            let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
-                eoa_signature(&signer_private_key, eoa_validator_address, hash)
-            });
-            Signer { provider: signature_provider, stub_signature: stub_sig }
-        };
+        let signer = create_eoa_signer(
+            signer_private_key.clone(),
+            eoa_validator_address,
+        )?;
 
         add_owner(
             account_address,

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/passkey/remove.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/passkey/remove.rs
@@ -86,25 +86,21 @@ mod tests {
                 modular_smart_account::{
                     add_passkey::PasskeyPayload,
                     deploy::{DeployAccountParams, EOASigners, deploy_account},
-                    signers::{
-                        eoa::{eoa_signature, stub_signature_eoa},
-                        passkey::{
-                            active::{PasskeyDetails, get_active_passkeys},
-                            add::add_passkey,
-                        },
+                    signers::passkey::{
+                        active::{PasskeyDetails, get_active_passkeys},
+                        add::add_passkey,
                     },
                     test_utilities::fund_account_with_default_amount,
                 },
             },
-            signer::Signer,
+            signer::create_eoa_signer,
         },
         utils::alloy_utilities::test_utilities::{
             TestInfraConfig,
             start_anvil_and_deploy_contracts_and_start_bundler_with_config,
         },
     };
-    use alloy::primitives::{FixedBytes, address, bytes, fixed_bytes};
-    use std::sync::Arc;
+    use alloy::primitives::{address, bytes, fixed_bytes};
 
     #[tokio::test]
     async fn test_remove_passkey() -> eyre::Result<()> {
@@ -168,14 +164,10 @@ mod tests {
             .await?;
 
         // Install WebAuthn module
-        let signer = {
-            let stub_sig = stub_signature_eoa(eoa_validator_address)?;
-            let signer_private_key = signer_private_key.clone();
-            let signature_provider = Arc::new(move |hash: FixedBytes<32>| {
-                eoa_signature(&signer_private_key, eoa_validator_address, hash)
-            });
-            Signer { provider: signature_provider, stub_signature: stub_sig }
-        };
+        let signer = create_eoa_signer(
+            signer_private_key.clone(),
+            eoa_validator_address,
+        )?;
 
         add_module(
             account_address,

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/sign_typed_data.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/account/modular_smart_account/signers/sign_typed_data.rs
@@ -44,9 +44,10 @@ where
         caller_domain,
         sign,
     )
+    .await
 }
 
-fn sign_typed_data_with_domains(
+async fn sign_typed_data_with_domains(
     message_types: serde_json::Map<String, serde_json::Value>,
     message: serde_json::Value,
     primary_type: String,
@@ -139,7 +140,7 @@ fn sign_typed_data_with_domains(
 
     let final_hash = typed_data.eip712_signing_hash()?;
 
-    let original_signature = sign(final_hash)?;
+    let original_signature = sign(final_hash).await?;
 
     let final_signature: Vec<u8> = {
         let domain_seperator = typed_data.domain().separator();
@@ -167,20 +168,17 @@ fn sign_typed_data_with_domains(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::erc4337::account::modular_smart_account::signers::eoa::eoa_signature;
+    use crate::erc4337::signer::create_eoa_signer;
     use alloy::primitives::{FixedBytes, U256, address, bytes};
-    use std::sync::Arc;
 
-    #[test]
-    fn test_sign_typed_data() -> eyre::Result<()> {
+    #[tokio::test]
+    async fn test_sign_typed_data() -> eyre::Result<()> {
         let eoa_validator_address =
             address!("0xF62849F9A0B5Bf2913b396098F7c7019b51A820a");
-        let sign = {
-            let signer_private_key: String = "0x02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c0".to_string();
-            Arc::new(move |hash: FixedBytes<32>| {
-                eoa_signature(&signer_private_key, eoa_validator_address, hash)
-            })
-        };
+        let signer_private_key: String = "0x02016836a56b71f0d02689e69e326f4f4c1b9057164ef592671cf0d37c8040c0".to_string();
+        let signer =
+            create_eoa_signer(signer_private_key, eoa_validator_address)?;
+        let sign: SignatureProvider = signer.provider;
 
         let contract_address =
             address!("0xA4AD4f68d0b91CFD19687c881e50f3A00242828c");
@@ -230,7 +228,8 @@ mod tests {
             account_domain,
             caller_domain,
             sign,
-        )?;
+        )
+        .await?;
 
         let expected_signature = bytes!(
             "0xf62849f9a0b5bf2913b396098f7c7019b51a820a3348056b01d55830973942a1a8c01359ecb6aef2e1d08cfa1b470d835a310aae204c66c0dcee0e53c4c37a2e6906ad3d36ea8188588ae6448a151a829ac74e491baa335e38a793ec8c04d12c9496bc1ee26e40779883a74d6dd1781f4b7a537b968f3e8c20dbe17618cf006de0a778efbb171a55529fb1c077086c27d407c8e5504d6f636b4d65737361676528737472696e67206d6573736167652c75696e743235362076616c7565290029"

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/signer.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/signer.rs
@@ -1,4 +1,10 @@
+#[cfg(any(test, feature = "test-utilities"))]
+pub mod test_utils;
+
 use crate::erc4337::{
+    account::modular_smart_account::signers::eoa::{
+        eoa_signature, stub_signature_eoa,
+    },
     entry_point::PackedUserOperation,
     user_operation::wrapper_v07::PackedUserOperationWrapperV07,
 };
@@ -8,15 +14,49 @@ use alloy::{
     signers::{SignerSync, local::PrivateKeySigner},
 };
 use eyre;
-use std::sync::Arc;
+use std::{future::Future, pin::Pin, sync::Arc};
 
-pub type SignatureProvider =
-    Arc<dyn Fn(FixedBytes<32>) -> eyre::Result<Bytes> + Send + Sync>;
+pub type SignatureProvider = Arc<
+    dyn Fn(
+            FixedBytes<32>,
+        ) -> Pin<Box<dyn Future<Output = eyre::Result<Bytes>> + Send>>
+        + Send
+        + Sync,
+>;
 
 #[derive(Clone)]
 pub struct Signer {
     pub stub_signature: Bytes,
     pub provider: SignatureProvider,
+}
+
+pub fn create_eoa_signer(
+    private_key_hex: String,
+    eoa_validator_address: Address,
+) -> eyre::Result<Signer> {
+    let stub_sig = stub_signature_eoa(eoa_validator_address)?;
+
+    let private_key_hex_clone = private_key_hex.clone();
+    let eoa_validator_address_clone = eoa_validator_address;
+
+    let signature_provider =
+        Arc::new(
+            move |hash: FixedBytes<32>| -> Pin<
+                Box<dyn Future<Output = eyre::Result<Bytes>> + Send>,
+            > {
+                let private_key_hex = private_key_hex_clone.clone();
+                Box::pin(async move {
+                    eoa_signature(
+                        &private_key_hex,
+                        eoa_validator_address_clone,
+                        hash,
+                    )
+                })
+                    as Pin<Box<dyn Future<Output = eyre::Result<Bytes>> + Send>>
+            },
+        );
+
+    Ok(Signer { stub_signature: stub_sig, provider: signature_provider })
 }
 
 pub fn sign_user_operation_v07_with_ecdsa(

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/signer/test_utils.rs
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-core/src/erc4337/signer/test_utils.rs
@@ -1,0 +1,51 @@
+use crate::erc4337::signer::{SignatureProvider, Signer};
+use alloy::primitives::{Bytes, FixedBytes};
+use eyre;
+use std::{pin::Pin, process::Command, str::FromStr, sync::Arc};
+
+pub fn get_signature_from_js(hash: String) -> eyre::Result<Bytes> {
+    let working_dir = "../../../../../erc4337-contracts";
+
+    let output = Command::new("pnpm")
+        .arg("tsx")
+        .arg("test/integration/utils.ts")
+        .arg("--hash")
+        .arg(&hash)
+        .current_dir(working_dir)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eyre::bail!("Failed to sign hash with passkey: {}", stderr);
+    }
+
+    let stdout = String::from_utf8(output.stdout)?;
+
+    let last_line =
+        stdout.lines().filter(|line| !line.is_empty()).next_back().ok_or_else(
+            || eyre::eyre!("No output from sign_hash_with_passkey command"),
+        )?;
+
+    let hex_sig = last_line.trim();
+    let bytes = Bytes::from_str(hex_sig)?;
+
+    Ok(bytes)
+}
+
+pub fn create_test_webauthn_js_signer() -> Signer {
+    let stub_sig =
+        get_signature_from_js(FixedBytes::<32>::default().to_string())
+            .expect("Failed to create stub signature for WebAuthn signer");
+
+    let signature_provider: SignatureProvider =
+        Arc::new(
+            move |hash: FixedBytes<32>| -> Pin<
+                Box<dyn Future<Output = eyre::Result<Bytes>> + Send>,
+            > {
+                Box::pin(async move { get_signature_from_js(hash.to_string()) })
+                    as Pin<Box<dyn Future<Output = eyre::Result<Bytes>> + Send>>
+            },
+        );
+
+    Signer { stub_signature: stub_sig, provider: signature_provider }
+}

--- a/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-ffi-web/Cargo.toml
+++ b/packages/sdk-platforms/rust/zksync-sso-erc4337/crates/zksync-sso-erc4337-ffi-web/Cargo.toml
@@ -33,6 +33,7 @@ uniffi.workspace = true
 
 # Error handling
 thiserror.workspace = true
+eyre.workspace = true
 
 # Logging/Tracing
 tracing.workspace = true


### PR DESCRIPTION
# Description

Changes the `Signer` interface to be `async` to enable passkey signers which need to be `async`.
