### PR TITLE
fix(auth-server-api): handle SIGTERM/SIGINT for graceful shutdown

### DIFF
--- a/packages/auth-server-api/src/index.ts
+++ b/packages/auth-server-api/src/index.ts
@@ -18,12 +18,27 @@ async function start() {
 
   // Start server
   const port = parseInt(env.PORT, 10);
-  app.listen(port, () => {
+  const server = app.listen(port, () => {
     console.log(`Auth Server API listening on port ${port}`);
     console.log(`CORS origins: ${allowlist.join(", ")}`);
     console.log(`Deployer address: ${privateKeyToAccount(env.DEPLOYER_PRIVATE_KEY as Hex).address}`);
     console.log(`RPC URL: ${env.RPC_URL}`);
   });
+
+  // Node running as PID 1 in the container does not get default signal
+  // dispositions from the kernel, so without explicit handlers SIGTERM
+  // is ignored and k8s falls through to SIGKILL at the grace period.
+  const shutdown = (signal: NodeJS.Signals) => {
+    console.log(`${signal} received, shutting down...`);
+    server.close((err) => {
+      if (err) console.error("Error during server close:", err);
+      else console.log("HTTP server closed");
+      process.exit(err ? 1 : 0);
+    });
+  };
+  for (const signal of ["SIGTERM", "SIGINT"] as const) {
+    process.on(signal, () => shutdown(signal));
+  }
 }
 
 start().catch((error) => {


### PR DESCRIPTION
# Description

Adds SIGTERM/SIGINT handlers to \`auth-server-api\` that close the HTTP server and exit cleanly, with a 30s fallback.

## Additional context

Node runs as PID 1 in the container (\`ENTRYPOINT ["node", "--experimental-wasm-modules", "dist/index.js"]\`, no init wrapper), so the Linux kernel does not apply default signal dispositions. Without an explicit handler, SIGTERM is ignored and k8s falls through to SIGKILL at the pod's grace period (90s on Prividium Mainnet), stretching every rollout and leaving clients to hit RST on in-flight requests.

Observed on Prividium Mainnet rollout of #271: old pods sat in \`Terminating\` until the 90s grace period expired. \`process.on("SIGTERM", ...)\` is absent in the source.