### PR TITLE
fix: repair Prividium account deployment registration

### DIFF
--- a/packages/auth-server-api/package.json
+++ b/packages/auth-server-api/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "node --experimental-wasm-modules --import tsx src/index.ts",
-    "start": "node --experimental-wasm-modules dist/index.js"
+    "start": "node --experimental-wasm-modules dist/index.js",
+    "test": "node --import tsx --test test/**/*.test.ts"
   },
   "dependencies": {
     "@simplewebauthn/browser": "13.x",

--- a/packages/auth-server-api/package.json
+++ b/packages/auth-server-api/package.json
@@ -16,7 +16,7 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-rate-limit": "^7.5.0",
-    "prividium": "^0.15.1",
+    "prividium": "^0.18.0",
     "viem": "2.30.0",
     "zksync-sso": "workspace:*",
     "zod": "^3.24.1"

--- a/packages/auth-server-api/src/handlers/deploy-account.ts
+++ b/packages/auth-server-api/src/handlers/deploy-account.ts
@@ -168,22 +168,12 @@ export const deployAccountHandler = async (req: Request, res: Response): Promise
 
     // Prividium post-deployment steps (all blocking)
     if (prividiumConfig.enabled && req.prividiumUser && adminSdk) {
-      // Get auth headers from SDK
-      const authHeaders = adminSdk.getAuthHeaders();
-      if (!authHeaders) {
-        console.error("Failed to get auth headers");
-        res.status(500).json({
-          error: "Authentication error",
-        });
-        return;
-      }
-
       // Step 1: Whitelist the contract with template (blocking)
       try {
         await whitelistContract(
           deployedAddress,
           prividiumConfig.templateKey,
-          authHeaders,
+          adminSdk,
           prividiumConfig.apiUrl,
         );
       } catch (error) {
@@ -199,7 +189,7 @@ export const deployAccountHandler = async (req: Request, res: Response): Promise
         await addAddressToUser(
           req.prividiumUser.userId,
           [deployedAddress],
-          authHeaders,
+          adminSdk,
           prividiumConfig.apiUrl,
         );
       } catch (error) {

--- a/packages/auth-server-api/src/services/prividium/address-association.ts
+++ b/packages/auth-server-api/src/services/prividium/address-association.ts
@@ -1,5 +1,6 @@
 import type { Hex } from "viem";
 
+import { authenticatedFetch, type PrividiumApiAuth } from "./authenticated-fetch.js";
 import type { FullUserResponse } from "./types.js";
 
 /**
@@ -12,19 +13,18 @@ import type { FullUserResponse } from "./types.js";
  *
  * @param userId The Prividium user ID to add addresses to
  * @param addresses Array of wallet addresses to associate
- * @param authHeaders The authentication headers from SDK
+ * @param auth The admin authentication provider from SDK
  * @param apiUrl The base URL for the Prividium API
  */
 export async function addAddressToUser(
   userId: string,
   addresses: Hex[],
-  authHeaders: Record<string, string>,
+  auth: PrividiumApiAuth,
   apiUrl: string,
 ): Promise<void> {
   // Step 1: Get current user data
-  const getUserResponse = await fetch(`${apiUrl}/api/users/${userId}`, {
+  const getUserResponse = await authenticatedFetch(auth, `${apiUrl}/api/users/${userId}`, {
     method: "GET",
-    headers: authHeaders,
   });
 
   if (!getUserResponse.ok) {
@@ -39,10 +39,9 @@ export async function addAddressToUser(
   const allWallets = [...new Set([...existingWallets, ...addresses])];
 
   // Step 2: Update user with new wallets
-  const updateResponse = await fetch(`${apiUrl}/api/users/${userId}`, {
+  const updateResponse = await authenticatedFetch(auth, `${apiUrl}/api/users/${userId}`, {
     method: "PUT",
     headers: {
-      ...authHeaders,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({

--- a/packages/auth-server-api/src/services/prividium/authenticated-fetch.ts
+++ b/packages/auth-server-api/src/services/prividium/authenticated-fetch.ts
@@ -34,13 +34,17 @@ export async function authenticatedFetch(
   input: Parameters<typeof fetch>[0],
   init?: Parameters<typeof fetch>[1],
 ): Promise<Response> {
-  const send = async () => fetch(input, withAuthHeaders(init, await getFreshAuthHeaders(auth)));
+  const send = (headers: Record<string, string>) => fetch(input, withAuthHeaders(init, headers));
 
-  const response = await send();
+  const response = await send(await getFreshAuthHeaders(auth));
   if (response.status !== 401) {
     return response;
   }
 
   await auth.authorize();
-  return send();
+  const refreshedHeaders = auth.getAuthHeaders();
+  if (!refreshedHeaders) {
+    throw new Error("Failed to get auth headers after reauthorization");
+  }
+  return send(refreshedHeaders);
 }

--- a/packages/auth-server-api/src/services/prividium/authenticated-fetch.ts
+++ b/packages/auth-server-api/src/services/prividium/authenticated-fetch.ts
@@ -1,0 +1,46 @@
+export type PrividiumApiAuth = {
+  getAuthHeaders(): Record<string, string> | null;
+  authorize(): Promise<unknown>;
+};
+
+function withAuthHeaders(init: RequestInit | undefined, authHeaders: Record<string, string>): RequestInit {
+  const headers = new Headers(init?.headers);
+  for (const [key, value] of Object.entries(authHeaders)) {
+    headers.set(key, value);
+  }
+
+  return {
+    ...init,
+    headers,
+  };
+}
+
+async function getFreshAuthHeaders(auth: PrividiumApiAuth): Promise<Record<string, string>> {
+  const authHeaders = auth.getAuthHeaders();
+  if (authHeaders) {
+    return authHeaders;
+  }
+
+  await auth.authorize();
+  const refreshedHeaders = auth.getAuthHeaders();
+  if (!refreshedHeaders) {
+    throw new Error("Failed to get auth headers");
+  }
+  return refreshedHeaders;
+}
+
+export async function authenticatedFetch(
+  auth: PrividiumApiAuth,
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+): Promise<Response> {
+  const send = async () => fetch(input, withAuthHeaders(init, await getFreshAuthHeaders(auth)));
+
+  const response = await send();
+  if (response.status !== 401) {
+    return response;
+  }
+
+  await auth.authorize();
+  return send();
+}

--- a/packages/auth-server-api/src/services/prividium/contract-whitelist.ts
+++ b/packages/auth-server-api/src/services/prividium/contract-whitelist.ts
@@ -1,5 +1,7 @@
 import type { Hex } from "viem";
 
+import { authenticatedFetch, type PrividiumApiAuth } from "./authenticated-fetch.js";
+
 /**
  * Whitelists a contract address in Prividium by creating a contract entry
  * with a template key. This allows the contract to inherit permissions
@@ -7,19 +9,18 @@ import type { Hex } from "viem";
  *
  * @param contractAddress The deployed contract address to whitelist
  * @param templateKey The template key to associate with the contract
- * @param authHeaders The authentication headers from SDK
+ * @param auth The admin authentication provider from SDK
  * @param apiUrl The base URL for the Prividium API
  */
 export async function whitelistContract(
   contractAddress: Hex,
   templateKey: string,
-  authHeaders: Record<string, string>,
+  auth: PrividiumApiAuth,
   apiUrl: string,
 ): Promise<void> {
-  const response = await fetch(`${apiUrl}/api/contracts`, {
+  const response = await authenticatedFetch(auth, `${apiUrl}/api/contracts`, {
     method: "POST",
     headers: {
-      ...authHeaders,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
@@ -28,7 +29,7 @@ export async function whitelistContract(
       abi: "[]",
       name: null,
       description: null,
-      discloseErc20Balance: false,
+      discloseErc20TotalSupply: false,
       discloseBytecode: false,
     }),
   });

--- a/packages/auth-server-api/src/services/prividium/index.ts
+++ b/packages/auth-server-api/src/services/prividium/index.ts
@@ -1,5 +1,6 @@
 export * from "./address-association.js";
 export * from "./admin-auth.js";
+export * from "./authenticated-fetch.js";
 export * from "./contract-whitelist.js";
 export * from "./types.js";
 export * from "./user-auth.js";

--- a/packages/auth-server-api/test/prividium-services.test.ts
+++ b/packages/auth-server-api/test/prividium-services.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import { authenticatedFetch, type PrividiumApiAuth } from "../src/services/prividium/authenticated-fetch.ts";
+import { whitelistContract } from "../src/services/prividium/contract-whitelist.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("authenticatedFetch", () => {
+  it("uses cached auth headers without reauthorizing", async () => {
+    const auth: PrividiumApiAuth = {
+      getAuthHeaders: () => ({ Authorization: "Bearer cached-token" }),
+      authorize: async () => {
+        throw new Error("authorize should not be called");
+      },
+    };
+
+    globalThis.fetch = (async (_url, init) => {
+      assert.equal(new Headers(init?.headers).get("Authorization"), "Bearer cached-token");
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const response = await authenticatedFetch(auth, "https://api.example.com/api/contracts");
+
+    assert.equal(response.status, 200);
+  });
+
+  it("reauthorizes and retries once after a 401 response", async () => {
+    let token = "old-token";
+    let authorizeCalls = 0;
+    const seenTokens: string[] = [];
+    const auth: PrividiumApiAuth = {
+      getAuthHeaders: () => ({ Authorization: `Bearer ${token}` }),
+      authorize: async () => {
+        authorizeCalls++;
+        token = "new-token";
+      },
+    };
+
+    globalThis.fetch = (async (_url, init) => {
+      seenTokens.push(new Headers(init?.headers).get("Authorization") ?? "");
+      if (seenTokens.length === 1) {
+        return new Response("{}", { status: 401 });
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+
+    const response = await authenticatedFetch(auth, "https://api.example.com/api/contracts");
+
+    assert.equal(response.status, 200);
+    assert.equal(authorizeCalls, 1);
+    assert.deepEqual(seenTokens, ["Bearer old-token", "Bearer new-token"]);
+  });
+});
+
+describe("whitelistContract", () => {
+  it("sends Prividium contract disclosure fields expected by the API", async () => {
+    let requestBody: unknown;
+    const auth: PrividiumApiAuth = {
+      getAuthHeaders: () => ({ Authorization: "Bearer token" }),
+      authorize: async () => {},
+    };
+
+    globalThis.fetch = (async (_url, init) => {
+      requestBody = JSON.parse(init?.body as string);
+      return new Response("{}", { status: 201 });
+    }) as typeof fetch;
+
+    await whitelistContract(
+      "0x1234567890123456789012345678901234567890",
+      "sso-account",
+      auth,
+      "https://api.example.com",
+    );
+
+    assert.deepEqual(requestBody, {
+      contractAddress: "0x1234567890123456789012345678901234567890",
+      templateKey: "sso-account",
+      abi: "[]",
+      name: null,
+      description: null,
+      discloseErc20TotalSupply: false,
+      discloseBytecode: false,
+    });
+  });
+});

--- a/packages/auth-server/package.json
+++ b/packages/auth-server/package.json
@@ -30,7 +30,7 @@
     "nuxt-typed-router": "3.7.3",
     "pinia": "^2.1.7",
     "prettier": "^2.5.x || 3.x",
-    "prividium": "^0.15.1",
+    "prividium": "^0.18.0",
     "radix-vue": "^1.9.6",
     "sass": "^1.77.6",
     "snarkjs": "^0.7.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,7 +144,7 @@ importers:
     dependencies:
       '@heroicons/vue':
         specifier: ^2.1.5
-        version: 2.1.5(vue@3.5.32(typescript@5.6.2))
+        version: 2.1.5(vue@3.5.34(typescript@5.6.2))
       '@nuxt/eslint':
         specifier: ^0.5.7
         version: 0.5.7(bufferutil@4.0.8)(eslint@9.11.1(jiti@2.4.2))(magicast@0.3.5)(rollup@4.30.1)(typescript@5.6.2)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))
@@ -159,7 +159,7 @@ importers:
         version: 6.12.2(magicast@0.3.5)(rollup@4.30.1)(ts-node@10.9.2(@swc/core@1.15.2(@swc/helpers@0.5.13))(@swc/wasm@1.15.2)(@types/node@24.3.3)(typescript@5.6.2))
       '@pinia/nuxt':
         specifier: ^0.5.1
-        version: 0.5.5(magicast@0.3.5)(rollup@4.30.1)(typescript@5.6.2)(vue@3.5.32(typescript@5.6.2))
+        version: 0.5.5(magicast@0.3.5)(rollup@4.30.1)(typescript@5.6.2)(vue@3.5.34(typescript@5.6.2))
       '@reown/appkit':
         specifier: ^1.7.0
         version: 1.7.0(@types/react@19.1.8)(bufferutil@4.0.8)(ioredis@5.4.1)(react@18.3.1)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1)
@@ -171,22 +171,22 @@ importers:
         version: 1.2.1(bufferutil@4.0.8)(ioredis@5.4.1)(utf-8-validate@5.0.10)
       '@tanstack/vue-query':
         specifier: ^5.59.16
-        version: 5.59.16(vue@3.5.32(typescript@5.6.2))
+        version: 5.59.16(vue@3.5.34(typescript@5.6.2))
       '@vue/devtools-api':
         specifier: ^7.7.1
         version: 7.7.1
       '@vueuse/core':
         specifier: ^11.1.0
-        version: 11.1.0(vue@3.5.32(typescript@5.6.2))
+        version: 11.1.0(vue@3.5.34(typescript@5.6.2))
       '@vueuse/nuxt':
         specifier: ^11.1.0
-        version: 11.1.0(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@24.3.3)(bufferutil@4.0.8)(eslint@9.11.1(jiti@2.4.2))(idb-keyval@6.2.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)))(rollup@4.30.1)(vue@3.5.32(typescript@5.6.2))
+        version: 11.1.0(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@24.3.3)(bufferutil@4.0.8)(eslint@9.11.1(jiti@2.4.2))(idb-keyval@6.2.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)))(rollup@4.30.1)(vue@3.5.34(typescript@5.6.2))
       '@wagmi/core':
         specifier: ^2.13.3
         version: 2.16.7(@tanstack/query-core@5.59.16)(@types/react@19.1.8)(immer@10.0.2)(react@18.3.1)(typescript@5.6.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1))
       '@wagmi/vue':
         specifier: ^0.1.14
-        version: 0.1.15(@tanstack/query-core@5.59.16)(@tanstack/vue-query@5.59.16(vue@3.5.32(typescript@5.6.2)))(@types/react@19.1.8)(bufferutil@4.0.8)(immer@10.0.2)(ioredis@5.4.1)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@24.3.3)(bufferutil@4.0.8)(eslint@9.11.1(jiti@2.4.2))(idb-keyval@6.2.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)))(react@18.3.1)(typescript@5.6.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1))(vue@3.5.32(typescript@5.6.2))(zod@3.24.1)
+        version: 0.1.15(@tanstack/query-core@5.59.16)(@tanstack/vue-query@5.59.16(vue@3.5.34(typescript@5.6.2)))(@types/react@19.1.8)(bufferutil@4.0.8)(immer@10.0.2)(ioredis@5.4.1)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@24.3.3)(bufferutil@4.0.8)(eslint@9.11.1(jiti@2.4.2))(idb-keyval@6.2.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)))(react@18.3.1)(typescript@5.6.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1))(vue@3.5.34(typescript@5.6.2))(zod@3.24.1)
       '@walletconnect/core':
         specifier: ^2.19.0
         version: 2.19.0(bufferutil@4.0.8)(ioredis@5.4.1)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1)
@@ -207,16 +207,16 @@ importers:
         version: 3.7.3(magicast@0.3.5)(prettier@3.3.3)(rollup@4.30.1)
       pinia:
         specifier: ^2.1.7
-        version: 2.2.4(typescript@5.6.2)(vue@3.5.32(typescript@5.6.2))
+        version: 2.2.4(typescript@5.6.2)(vue@3.5.34(typescript@5.6.2))
       prettier:
         specifier: ^2.5.x || 3.x
         version: 3.3.3
       prividium:
-        specifier: ^0.15.1
-        version: 0.15.1(@fastify/swagger@9.6.1)(bufferutil@4.0.8)(openapi-types@12.1.3)(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1))
+        specifier: ^0.18.0
+        version: 0.18.0(@fastify/swagger@9.6.1)(bufferutil@4.0.8)(openapi-types@12.1.3)(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1))
       radix-vue:
         specifier: ^1.9.6
-        version: 1.9.7(vue@3.5.32(typescript@5.6.2))
+        version: 1.9.7(vue@3.5.34(typescript@5.6.2))
       sass:
         specifier: ^1.77.6
         version: 1.80.4
@@ -231,13 +231,13 @@ importers:
         version: 2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1)
       vue:
         specifier: latest
-        version: 3.5.32(typescript@5.6.2)
+        version: 3.5.34(typescript@5.6.2)
       wagmi:
         specifier: ^2.12.17
         version: 2.14.15(@tanstack/query-core@5.59.16)(@tanstack/react-query@5.59.16(react@18.3.1))(@types/react@19.1.8)(bufferutil@4.0.8)(immer@10.0.2)(ioredis@5.4.1)(react@18.3.1)(typescript@5.6.2)(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
       web3-avatar-vue:
         specifier: ^1.0.5
-        version: 1.0.5(vue@3.5.32(typescript@5.6.2))
+        version: 1.0.5(vue@3.5.34(typescript@5.6.2))
       zksync-sso:
         specifier: workspace:*
         version: link:../sdk
@@ -288,8 +288,8 @@ importers:
         specifier: ^7.5.0
         version: 7.5.1(express@4.21.2)
       prividium:
-        specifier: ^0.15.1
-        version: 0.15.1(@fastify/swagger@9.6.1)(bufferutil@4.0.8)(openapi-types@12.1.3)(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1))
+        specifier: ^0.18.0
+        version: 0.18.0(@fastify/swagger@9.6.1)(bufferutil@4.0.8)(openapi-types@12.1.3)(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1))
       viem:
         specifier: 2.30.0
         version: 2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1)
@@ -449,7 +449,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.12
+        version: 1.3.13
       '@types/cors':
         specifier: ^2.8.17
         version: 2.8.19
@@ -702,6 +702,11 @@ packages:
 
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1143,10 +1148,6 @@ packages:
 
   '@babel/types@7.28.4':
     resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.28.5':
-    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -2326,8 +2327,8 @@ packages:
   '@fastify/forwarded@3.0.1':
     resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
 
-  '@fastify/http-proxy@11.4.1':
-    resolution: {integrity: sha512-sMYEIB0c7qCYutpZyS12c8xnVgmEMSUUVU2XjcNq2JzHf6Hta1BWcpnG5FXxR3WEm48uZNCi0MxnIYtwjwd21Q==}
+  '@fastify/http-proxy@11.4.4':
+    resolution: {integrity: sha512-wXoKaxW31pQc6H48Xqx//j6A2ikOiadht55DNkEFaseEUkJ9MzvURLK6Qqg0OOIEZGjTiEjjnbERv3NLFBc2Ug==}
 
   '@fastify/merge-json-schemas@0.1.1':
     resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
@@ -2338,8 +2339,8 @@ packages:
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
 
-  '@fastify/reply-from@12.5.0':
-    resolution: {integrity: sha512-m7mTGjgtnpnZBk4I8r6eFJY8WB4kyvXJo2nAf5PBm5f3mj3P7G6H2D7mhmF25os/n6EGMWVyw/bpTUehvy0i8g==}
+  '@fastify/reply-from@12.6.2':
+    resolution: {integrity: sha512-FhMvsRJa4HMG0q0/Yi06sgwVFd/Wc8E/+RbHsqB0Q+883C66RPrS6qwZKBPje2mVzsyEb9sjq7wlyvi35zRW0A==}
 
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
@@ -3922,6 +3923,7 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.22.2':
     resolution: {integrity: sha512-Y0yAxRaB98LFp2Dm+ACZqBSdAmI3FlpH/LjxOZ94g/ouuDJecSq0iR26XZ5QDuEL8Rf+L4jBJaoDC08CD0KkJw==}
     engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
@@ -4295,8 +4297,8 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
-  '@types/bun@1.3.12':
-    resolution: {integrity: sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A==}
+  '@types/bun@1.3.13':
+    resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
@@ -4522,6 +4524,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/dom@1.11.10':
     resolution: {integrity: sha512-nL1mdRzYVATZIYauK15zOI2YyM3YxCLfhbTqljEjDFJeiJUzTTi+a//5FHiUk84ewSucFnrwHNey/pEXFlyY1A==}
@@ -4637,38 +4640,38 @@ packages:
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
 
-  '@vue/compiler-core@3.5.31':
-    resolution: {integrity: sha512-k/ueL14aNIEy5Onf0OVzR8kiqF/WThgLdFhxwa4e/KF/0qe38IwIdofoSWBTvvxQOesaz6riAFAUaYjoF9fLLQ==}
-
   '@vue/compiler-core@3.5.32':
     resolution: {integrity: sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==}
+
+  '@vue/compiler-core@3.5.34':
+    resolution: {integrity: sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==}
 
   '@vue/compiler-dom@3.5.13':
     resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
 
-  '@vue/compiler-dom@3.5.31':
-    resolution: {integrity: sha512-BMY/ozS/xxjYqRFL+tKdRpATJYDTTgWSo0+AJvJNg4ig+Hgb0dOsHPXvloHQ5hmlivUqw1Yt2pPIqp4e0v1GUw==}
-
   '@vue/compiler-dom@3.5.32':
     resolution: {integrity: sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==}
+
+  '@vue/compiler-dom@3.5.34':
+    resolution: {integrity: sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==}
 
   '@vue/compiler-sfc@3.5.13':
     resolution: {integrity: sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==}
 
-  '@vue/compiler-sfc@3.5.31':
-    resolution: {integrity: sha512-M8wpPgR9UJ8MiRGjppvx9uWJfLV7A/T+/rL8s/y3QG3u0c2/YZgff3d6SuimKRIhcYnWg5fTfDMlz2E6seUW8Q==}
-
   '@vue/compiler-sfc@3.5.32':
     resolution: {integrity: sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==}
+
+  '@vue/compiler-sfc@3.5.34':
+    resolution: {integrity: sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==}
 
   '@vue/compiler-ssr@3.5.13':
     resolution: {integrity: sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==}
 
-  '@vue/compiler-ssr@3.5.31':
-    resolution: {integrity: sha512-h0xIMxrt/LHOvJKMri+vdYT92BrK3HFLtDqq9Pr/lVVfE4IyKZKvWf0vJFW10Yr6nX02OR4MkJwI0c1HDa1hog==}
-
   '@vue/compiler-ssr@3.5.32':
     resolution: {integrity: sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==}
+
+  '@vue/compiler-ssr@3.5.34':
+    resolution: {integrity: sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -4696,30 +4699,30 @@ packages:
   '@vue/reactivity@3.5.13':
     resolution: {integrity: sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==}
 
-  '@vue/reactivity@3.5.32':
-    resolution: {integrity: sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==}
+  '@vue/reactivity@3.5.34':
+    resolution: {integrity: sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==}
 
   '@vue/runtime-core@3.5.13':
     resolution: {integrity: sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==}
 
-  '@vue/runtime-core@3.5.32':
-    resolution: {integrity: sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==}
+  '@vue/runtime-core@3.5.34':
+    resolution: {integrity: sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==}
 
   '@vue/runtime-dom@3.5.13':
     resolution: {integrity: sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==}
 
-  '@vue/runtime-dom@3.5.32':
-    resolution: {integrity: sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==}
+  '@vue/runtime-dom@3.5.34':
+    resolution: {integrity: sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==}
 
   '@vue/server-renderer@3.5.13':
     resolution: {integrity: sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==}
     peerDependencies:
       vue: 3.5.13
 
-  '@vue/server-renderer@3.5.32':
-    resolution: {integrity: sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==}
+  '@vue/server-renderer@3.5.34':
+    resolution: {integrity: sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==}
     peerDependencies:
-      vue: 3.5.32
+      vue: 3.5.34
 
   '@vue/shared@3.5.12':
     resolution: {integrity: sha512-L2RPSAwUFbgZH20etwrXyVyCBu9OxRSi8T/38QsvnkJyvq2LufW2lDCOzm7t/U9C1mkhJGWYfCuFBCmIuNivrg==}
@@ -4727,11 +4730,11 @@ packages:
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
 
-  '@vue/shared@3.5.31':
-    resolution: {integrity: sha512-nBxuiuS9Lj5bPkPbWogPUnjxxWpkRniX7e5UBQDWl6Fsf4roq9wwV+cR7ezQ4zXswNvPIlsdj1slcLB7XCsRAw==}
-
   '@vue/shared@3.5.32':
     resolution: {integrity: sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==}
+
+  '@vue/shared@3.5.34':
+    resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
 
   '@vueuse/core@10.11.1':
     resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
@@ -5367,6 +5370,9 @@ packages:
   blake2b-wasm@2.4.0:
     resolution: {integrity: sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==}
 
+  blakejs@1.2.1:
+    resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
+
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
@@ -5436,8 +5442,8 @@ packages:
     resolution: {integrity: sha512-lDsx2BzkKe7gkCYiT5Acj02DpTwDznl/VNN7Psn7M3USPG7Vs/BaClZJJTAG+ufAR9++N1/NiUTdaFBWDIl5TQ==}
     engines: {node: '>=12'}
 
-  bun-types@1.3.12:
-    resolution: {integrity: sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA==}
+  bun-types@1.3.13:
+    resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -6622,9 +6628,6 @@ packages:
   fast-uri@2.4.0:
     resolution: {integrity: sha512-ypuAmmMKInk5q7XcepxlnUWDLWv4GFtaJqAzWKqn62IpQ3pejtr5dTVbt3vwqVaMKmkNR55sTT+CqUKIaT21BA==}
 
-  fast-uri@3.0.3:
-    resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
-
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -6648,8 +6651,8 @@ packages:
   fastify@4.29.1:
     resolution: {integrity: sha512-m2kMNHIG92tSNWv+Z3UeTR9AWLLuo7KctC7mlFPtMEVrfjIhmQhkQnT9v15qA/BfVq3vvj134Y0jl9SBje3jXQ==}
 
-  fastify@5.7.4:
-    resolution: {integrity: sha512-e6l5NsRdaEP8rdD8VR0ErJASeyaRbzXYpmkrpr2SuvuMq6Si3lvsaVy5C+7gLanEkvjpMDzBXWE5HPeb/hgTxA==}
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -8747,6 +8750,10 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -8801,8 +8808,8 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  prividium@0.15.1:
-    resolution: {integrity: sha512-OqlvR7zAYYxhwAxAeMPTo2NKhZVqb21pxhryCb8U2wA3rypLcJjXzjIAzHinZ/b9VYSbjADJJyCBPDF+9UzZew==}
+  prividium@0.18.0:
+    resolution: {integrity: sha512-VYF2JxMvFfKJrFE67E5KbjXCqpQppoqJGEr7cyk1MScxtG9ZFDoIip4mhHMkalrQBzYwEAnIdMv3zVquRgKcfA==}
     hasBin: true
     peerDependencies:
       viem: '>=2.0.0'
@@ -9964,14 +9971,17 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -10256,8 +10266,8 @@ packages:
       typescript:
         optional: true
 
-  vue@3.5.32:
-    resolution: {integrity: sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==}
+  vue@3.5.34:
+    resolution: {integrity: sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -10612,7 +10622,7 @@ snapshots:
 
   '@babel/generator@7.26.0':
     dependencies:
-      '@babel/parser': 7.26.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.26.0
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
@@ -10621,19 +10631,19 @@ snapshots:
   '@babel/generator@7.28.5':
     dependencies:
       '@babel/parser': 7.29.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.0.2
 
   '@babel/helper-annotate-as-pure@7.25.9':
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.0
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.25.9':
     dependencies:
       '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10679,7 +10689,7 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
       '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10701,7 +10711,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.25.9':
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.0
 
   '@babel/helper-plugin-utils@7.25.9': {}
 
@@ -10726,14 +10736,14 @@ snapshots:
   '@babel/helper-simple-access@7.25.9':
     dependencies:
       '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
     dependencies:
       '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10767,6 +10777,10 @@ snapshots:
       '@babel/types': 7.26.0
 
   '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
 
@@ -11304,14 +11318,14 @@ snapshots:
   '@babel/template@7.25.9':
     dependencies:
       '@babel/code-frame': 7.26.0
-      '@babel/parser': 7.26.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.26.0
 
   '@babel/traverse@7.25.9':
     dependencies:
       '@babel/code-frame': 7.26.0
       '@babel/generator': 7.28.5
-      '@babel/parser': 7.26.0
+      '@babel/parser': 7.29.2
       '@babel/template': 7.25.9
       '@babel/types': 7.26.0
       debug: 4.3.7
@@ -11328,11 +11342,6 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
-
-  '@babel/types@7.28.5':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.0':
     dependencies:
@@ -11417,7 +11426,7 @@ snapshots:
   '@commitlint/is-ignored@19.5.0':
     dependencies:
       '@commitlint/types': 19.5.0
-      semver: 7.6.3
+      semver: 7.7.3
 
   '@commitlint/lint@19.5.0':
     dependencies:
@@ -12269,9 +12278,9 @@ snapshots:
 
   '@fastify/forwarded@3.0.1': {}
 
-  '@fastify/http-proxy@11.4.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
+  '@fastify/http-proxy@11.4.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)':
     dependencies:
-      '@fastify/reply-from': 12.5.0
+      '@fastify/reply-from': 12.6.2
       fast-querystring: 1.1.2
       fastify-plugin: 5.1.0
       ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -12292,7 +12301,7 @@ snapshots:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.2.0
 
-  '@fastify/reply-from@12.5.0':
+  '@fastify/reply-from@12.6.2':
     dependencies:
       '@fastify/error': 4.2.0
       end-of-stream: 1.4.4
@@ -12349,11 +12358,11 @@ snapshots:
 
   '@floating-ui/utils@0.2.8': {}
 
-  '@floating-ui/vue@1.1.5(vue@3.5.32(typescript@5.6.2))':
+  '@floating-ui/vue@1.1.5(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@floating-ui/dom': 1.6.11
       '@floating-ui/utils': 0.2.8
-      vue-demi: 0.14.10(vue@3.5.32(typescript@5.6.2))
+      vue-demi: 0.14.10(vue@3.5.34(typescript@5.6.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -12370,9 +12379,9 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
-  '@heroicons/vue@2.1.5(vue@3.5.32(typescript@5.6.2))':
+  '@heroicons/vue@2.1.5(vue@3.5.34(typescript@5.6.2))':
     dependencies:
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
 
   '@hexagon/base64@1.1.28': {}
 
@@ -13014,15 +13023,15 @@ snapshots:
       pkg-types: 1.2.1
       prompts: 2.4.2
       rc9: 2.1.2
-      semver: 7.6.3
+      semver: 7.7.3
 
-  '@nuxt/devtools@1.6.0(bufferutil@4.0.8)(rollup@4.30.1)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))':
+  '@nuxt/devtools@1.6.0(bufferutil@4.0.8)(rollup@4.30.1)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@antfu/utils': 0.7.10
       '@nuxt/devtools-kit': 1.6.0(magicast@0.3.5)(rollup@4.30.1)(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))
       '@nuxt/devtools-wizard': 1.6.0
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.30.1)
-      '@vue/devtools-core': 7.4.4(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))
+      '@vue/devtools-core': 7.4.4(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))
       '@vue/devtools-kit': 7.4.4
       birpc: 0.2.19
       consola: 3.2.3
@@ -13064,13 +13073,13 @@ snapshots:
       - vue
       - webpack-sources
 
-  '@nuxt/devtools@1.6.0(bufferutil@4.0.8)(rollup@4.30.1)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))':
+  '@nuxt/devtools@1.6.0(bufferutil@4.0.8)(rollup@4.30.1)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@antfu/utils': 0.7.10
       '@nuxt/devtools-kit': 1.6.0(magicast@0.3.5)(rollup@4.30.1)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))
       '@nuxt/devtools-wizard': 1.6.0
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.30.1)
-      '@vue/devtools-core': 7.4.4(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))
+      '@vue/devtools-core': 7.4.4(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))
       '@vue/devtools-kit': 7.4.4
       birpc: 0.2.19
       consola: 3.2.3
@@ -13352,12 +13361,12 @@ snapshots:
       - supports-color
       - webpack-sources
 
-  '@nuxt/vite-builder@3.13.2(@types/node@22.8.0)(eslint@9.11.1(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(vue@3.5.32(typescript@5.6.2))':
+  '@nuxt/vite-builder@3.13.2(@types/node@22.8.0)(eslint@9.11.1(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.30.1)
       '@rollup/plugin-replace': 5.0.7(rollup@4.30.1)
-      '@vitejs/plugin-vue': 5.1.4(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))
-      '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))
+      '@vitejs/plugin-vue': 5.1.4(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))
+      '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))
       autoprefixer: 10.4.20(postcss@8.4.49)
       clear: 0.1.0
       consola: 3.2.3
@@ -13386,7 +13395,7 @@ snapshots:
       vite: 5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0)
       vite-node: 2.1.3(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0)
       vite-plugin-checker: 0.8.0(eslint@9.11.1(jiti@2.4.2))(optionator@0.9.4)(typescript@5.6.2)(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
       vue-bundle-renderer: 2.1.1
     transitivePeerDependencies:
       - '@biomejs/biome'
@@ -13411,12 +13420,12 @@ snapshots:
       - vue-tsc
       - webpack-sources
 
-  '@nuxt/vite-builder@3.13.2(@types/node@24.3.3)(eslint@9.11.1(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(vue@3.5.32(typescript@5.6.2))':
+  '@nuxt/vite-builder@3.13.2(@types/node@24.3.3)(eslint@9.11.1(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.30.1)
       '@rollup/plugin-replace': 5.0.7(rollup@4.30.1)
-      '@vitejs/plugin-vue': 5.1.4(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))
-      '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))
+      '@vitejs/plugin-vue': 5.1.4(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))
+      '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))
       autoprefixer: 10.4.20(postcss@8.4.49)
       clear: 0.1.0
       consola: 3.2.3
@@ -13445,7 +13454,7 @@ snapshots:
       vite: 5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)
       vite-node: 2.1.3(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)
       vite-plugin-checker: 0.8.0(eslint@9.11.1(jiti@2.4.2))(optionator@0.9.4)(typescript@5.6.2)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
       vue-bundle-renderer: 2.1.1
     transitivePeerDependencies:
       - '@biomejs/biome'
@@ -14604,10 +14613,10 @@ snapshots:
       - '@opentelemetry/api'
       - supports-color
 
-  '@pinia/nuxt@0.5.5(magicast@0.3.5)(rollup@4.30.1)(typescript@5.6.2)(vue@3.5.32(typescript@5.6.2))':
+  '@pinia/nuxt@0.5.5(magicast@0.3.5)(rollup@4.30.1)(typescript@5.6.2)(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@nuxt/kit': 3.15.2(magicast@0.3.5)(rollup@4.30.1)
-      pinia: 2.2.4(typescript@5.6.2)(vue@3.5.32(typescript@5.6.2))
+      pinia: 2.2.4(typescript@5.6.2)(vue@3.5.34(typescript@5.6.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - magicast
@@ -15479,18 +15488,18 @@ snapshots:
 
   '@tanstack/virtual-core@3.10.8': {}
 
-  '@tanstack/vue-query@5.59.16(vue@3.5.32(typescript@5.6.2))':
+  '@tanstack/vue-query@5.59.16(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@tanstack/match-sorter-utils': 8.19.4
       '@tanstack/query-core': 5.59.16
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.32(typescript@5.6.2)
-      vue-demi: 0.14.10(vue@3.5.32(typescript@5.6.2))
+      vue: 3.5.34(typescript@5.6.2)
+      vue-demi: 0.14.10(vue@3.5.34(typescript@5.6.2))
 
-  '@tanstack/vue-virtual@3.10.8(vue@3.5.32(typescript@5.6.2))':
+  '@tanstack/vue-virtual@3.10.8(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@tanstack/virtual-core': 3.10.8
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
 
   '@trysound/sax@0.2.0': {}
 
@@ -15511,9 +15520,9 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 22.15.33
 
-  '@types/bun@1.3.12':
+  '@types/bun@1.3.13':
     dependencies:
-      bun-types: 1.3.12
+      bun-types: 1.3.13
 
   '@types/connect@3.4.38':
     dependencies:
@@ -15748,7 +15757,7 @@ snapshots:
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.6.3
+      semver: 7.7.3
       ts-api-utils: 1.3.0(typescript@5.6.2)
     optionalDependencies:
       typescript: 5.6.2
@@ -15823,14 +15832,14 @@ snapshots:
       '@unhead/schema': 1.11.10
       '@unhead/shared': 1.11.10
 
-  '@unhead/vue@1.11.10(vue@3.5.32(typescript@5.6.2))':
+  '@unhead/vue@1.11.10(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@unhead/schema': 1.11.10
       '@unhead/shared': 1.11.10
       defu: 6.1.4
       hookable: 5.5.3
       unhead: 1.11.10
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
 
   '@vercel/nft@0.26.5':
     dependencies:
@@ -15850,35 +15859,35 @@ snapshots:
       - encoding
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.0.1(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))':
+  '@vitejs/plugin-vue-jsx@4.0.1(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-typescript': 7.25.9(@babel/core@7.26.0)
       '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.26.0)
       vite: 5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0)
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.0.1(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))':
+  '@vitejs/plugin-vue-jsx@4.0.1(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-typescript': 7.25.9(@babel/core@7.26.0)
       '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.26.0)
       vite: 5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.1.4(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))':
+  '@vitejs/plugin-vue@5.1.4(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       vite: 5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0)
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
 
-  '@vitejs/plugin-vue@5.1.4(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))':
+  '@vitejs/plugin-vue@5.1.4(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       vite: 5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
 
   '@vitest/expect@1.6.1':
     dependencies:
@@ -15962,16 +15971,16 @@ snapshots:
       '@eslint/config-array': 0.18.0
       '@nodelib/fs.walk': 2.0.0
 
-  '@vue-macros/common@1.15.0(rollup@4.30.1)(vue@3.5.32(typescript@5.6.2))':
+  '@vue-macros/common@1.15.0(rollup@4.30.1)(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@babel/types': 7.26.0
       '@rollup/pluginutils': 5.1.3(rollup@4.30.1)
-      '@vue/compiler-sfc': 3.5.31
+      '@vue/compiler-sfc': 3.5.32
       ast-kit: 1.3.0
       local-pkg: 0.5.1
       magic-string-ast: 0.6.2
     optionalDependencies:
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
     transitivePeerDependencies:
       - rollup
 
@@ -16001,7 +16010,7 @@ snapshots:
       '@babel/helper-module-imports': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
       '@babel/parser': 7.29.2
-      '@vue/compiler-sfc': 3.5.31
+      '@vue/compiler-sfc': 3.5.32
     transitivePeerDependencies:
       - supports-color
 
@@ -16013,18 +16022,18 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-core@3.5.31':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@vue/shared': 3.5.31
-      entities: 7.0.1
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
-
   '@vue/compiler-core@3.5.32':
     dependencies:
       '@babel/parser': 7.29.2
       '@vue/shared': 3.5.32
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-core@3.5.34':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@vue/shared': 3.5.34
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
@@ -16034,15 +16043,15 @@ snapshots:
       '@vue/compiler-core': 3.5.13
       '@vue/shared': 3.5.13
 
-  '@vue/compiler-dom@3.5.31':
-    dependencies:
-      '@vue/compiler-core': 3.5.31
-      '@vue/shared': 3.5.31
-
   '@vue/compiler-dom@3.5.32':
     dependencies:
       '@vue/compiler-core': 3.5.32
       '@vue/shared': 3.5.32
+
+  '@vue/compiler-dom@3.5.34':
+    dependencies:
+      '@vue/compiler-core': 3.5.34
+      '@vue/shared': 3.5.34
 
   '@vue/compiler-sfc@3.5.13':
     dependencies:
@@ -16054,18 +16063,6 @@ snapshots:
       estree-walker: 2.0.2
       magic-string: 0.30.14
       postcss: 8.4.49
-      source-map-js: 1.2.1
-
-  '@vue/compiler-sfc@3.5.31':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@vue/compiler-core': 3.5.31
-      '@vue/compiler-dom': 3.5.31
-      '@vue/compiler-ssr': 3.5.31
-      '@vue/shared': 3.5.31
-      estree-walker: 2.0.2
-      magic-string: 0.30.21
-      postcss: 8.5.8
       source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.32':
@@ -16080,20 +16077,32 @@ snapshots:
       postcss: 8.5.8
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.5.34':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@vue/compiler-core': 3.5.34
+      '@vue/compiler-dom': 3.5.34
+      '@vue/compiler-ssr': 3.5.34
+      '@vue/shared': 3.5.34
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.14
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.5.13':
     dependencies:
       '@vue/compiler-dom': 3.5.13
       '@vue/shared': 3.5.13
 
-  '@vue/compiler-ssr@3.5.31':
-    dependencies:
-      '@vue/compiler-dom': 3.5.31
-      '@vue/shared': 3.5.31
-
   '@vue/compiler-ssr@3.5.32':
     dependencies:
       '@vue/compiler-dom': 3.5.32
       '@vue/shared': 3.5.32
+
+  '@vue/compiler-ssr@3.5.34':
+    dependencies:
+      '@vue/compiler-dom': 3.5.34
+      '@vue/shared': 3.5.34
 
   '@vue/devtools-api@6.6.4': {}
 
@@ -16101,7 +16110,7 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 7.7.1
 
-  '@vue/devtools-core@7.4.4(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))':
+  '@vue/devtools-core@7.4.4(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@vue/devtools-kit': 7.4.4
       '@vue/devtools-shared': 7.5.4
@@ -16109,11 +16118,11 @@ snapshots:
       nanoid: 3.3.7
       pathe: 1.1.2
       vite-hot-client: 0.2.3(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
     transitivePeerDependencies:
       - vite
 
-  '@vue/devtools-core@7.4.4(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))':
+  '@vue/devtools-core@7.4.4(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@vue/devtools-kit': 7.4.4
       '@vue/devtools-shared': 7.5.4
@@ -16121,7 +16130,7 @@ snapshots:
       nanoid: 3.3.7
       pathe: 1.1.2
       vite-hot-client: 0.2.3(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
     transitivePeerDependencies:
       - vite
 
@@ -16157,19 +16166,19 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.13
 
-  '@vue/reactivity@3.5.32':
+  '@vue/reactivity@3.5.34':
     dependencies:
-      '@vue/shared': 3.5.32
+      '@vue/shared': 3.5.34
 
   '@vue/runtime-core@3.5.13':
     dependencies:
       '@vue/reactivity': 3.5.13
       '@vue/shared': 3.5.13
 
-  '@vue/runtime-core@3.5.32':
+  '@vue/runtime-core@3.5.34':
     dependencies:
-      '@vue/reactivity': 3.5.32
-      '@vue/shared': 3.5.32
+      '@vue/reactivity': 3.5.34
+      '@vue/shared': 3.5.34
 
   '@vue/runtime-dom@3.5.13':
     dependencies:
@@ -16178,11 +16187,11 @@ snapshots:
       '@vue/shared': 3.5.13
       csstype: 3.1.3
 
-  '@vue/runtime-dom@3.5.32':
+  '@vue/runtime-dom@3.5.34':
     dependencies:
-      '@vue/reactivity': 3.5.32
-      '@vue/runtime-core': 3.5.32
-      '@vue/shared': 3.5.32
+      '@vue/reactivity': 3.5.34
+      '@vue/runtime-core': 3.5.34
+      '@vue/shared': 3.5.34
       csstype: 3.2.3
 
   '@vue/server-renderer@3.5.13(vue@3.5.13(typescript@5.6.2))':
@@ -16191,36 +16200,36 @@ snapshots:
       '@vue/shared': 3.5.13
       vue: 3.5.13(typescript@5.6.2)
 
-  '@vue/server-renderer@3.5.32(vue@3.5.32(typescript@5.6.2))':
+  '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.6.2))':
     dependencies:
-      '@vue/compiler-ssr': 3.5.32
-      '@vue/shared': 3.5.32
-      vue: 3.5.32(typescript@5.6.2)
+      '@vue/compiler-ssr': 3.5.34
+      '@vue/shared': 3.5.34
+      vue: 3.5.34(typescript@5.6.2)
 
   '@vue/shared@3.5.12': {}
 
   '@vue/shared@3.5.13': {}
 
-  '@vue/shared@3.5.31': {}
-
   '@vue/shared@3.5.32': {}
 
-  '@vueuse/core@10.11.1(vue@3.5.32(typescript@5.6.2))':
+  '@vue/shared@3.5.34': {}
+
+  '@vueuse/core@10.11.1(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.32(typescript@5.6.2))
-      vue-demi: 0.14.10(vue@3.5.32(typescript@5.6.2))
+      '@vueuse/shared': 10.11.1(vue@3.5.34(typescript@5.6.2))
+      vue-demi: 0.14.10(vue@3.5.34(typescript@5.6.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@11.1.0(vue@3.5.32(typescript@5.6.2))':
+  '@vueuse/core@11.1.0(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 11.1.0
-      '@vueuse/shared': 11.1.0(vue@3.5.32(typescript@5.6.2))
-      vue-demi: 0.14.10(vue@3.5.32(typescript@5.6.2))
+      '@vueuse/shared': 11.1.0(vue@3.5.34(typescript@5.6.2))
+      vue-demi: 0.14.10(vue@3.5.34(typescript@5.6.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -16229,14 +16238,14 @@ snapshots:
 
   '@vueuse/metadata@11.1.0': {}
 
-  '@vueuse/nuxt@11.1.0(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@24.3.3)(bufferutil@4.0.8)(eslint@9.11.1(jiti@2.4.2))(idb-keyval@6.2.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)))(rollup@4.30.1)(vue@3.5.32(typescript@5.6.2))':
+  '@vueuse/nuxt@11.1.0(magicast@0.3.5)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@24.3.3)(bufferutil@4.0.8)(eslint@9.11.1(jiti@2.4.2))(idb-keyval@6.2.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)))(rollup@4.30.1)(vue@3.5.34(typescript@5.6.2))':
     dependencies:
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.30.1)
-      '@vueuse/core': 11.1.0(vue@3.5.32(typescript@5.6.2))
+      '@vueuse/core': 11.1.0(vue@3.5.34(typescript@5.6.2))
       '@vueuse/metadata': 11.1.0
       local-pkg: 0.5.0
       nuxt: 3.13.2(@parcel/watcher@2.4.1)(@types/node@24.3.3)(bufferutil@4.0.8)(eslint@9.11.1(jiti@2.4.2))(idb-keyval@6.2.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))
-      vue-demi: 0.14.10(vue@3.5.32(typescript@5.6.2))
+      vue-demi: 0.14.10(vue@3.5.34(typescript@5.6.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - magicast
@@ -16245,16 +16254,16 @@ snapshots:
       - vue
       - webpack-sources
 
-  '@vueuse/shared@10.11.1(vue@3.5.32(typescript@5.6.2))':
+  '@vueuse/shared@10.11.1(vue@3.5.34(typescript@5.6.2))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.32(typescript@5.6.2))
+      vue-demi: 0.14.10(vue@3.5.34(typescript@5.6.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@11.1.0(vue@3.5.32(typescript@5.6.2))':
+  '@vueuse/shared@11.1.0(vue@3.5.34(typescript@5.6.2))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.32(typescript@5.6.2))
+      vue-demi: 0.14.10(vue@3.5.34(typescript@5.6.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -16395,13 +16404,13 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/vue@0.1.15(@tanstack/query-core@5.59.16)(@tanstack/vue-query@5.59.16(vue@3.5.32(typescript@5.6.2)))(@types/react@19.1.8)(bufferutil@4.0.8)(immer@10.0.2)(ioredis@5.4.1)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@24.3.3)(bufferutil@4.0.8)(eslint@9.11.1(jiti@2.4.2))(idb-keyval@6.2.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)))(react@18.3.1)(typescript@5.6.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1))(vue@3.5.32(typescript@5.6.2))(zod@3.24.1)':
+  '@wagmi/vue@0.1.15(@tanstack/query-core@5.59.16)(@tanstack/vue-query@5.59.16(vue@3.5.34(typescript@5.6.2)))(@types/react@19.1.8)(bufferutil@4.0.8)(immer@10.0.2)(ioredis@5.4.1)(nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@24.3.3)(bufferutil@4.0.8)(eslint@9.11.1(jiti@2.4.2))(idb-keyval@6.2.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)))(react@18.3.1)(typescript@5.6.2)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1))(vue@3.5.34(typescript@5.6.2))(zod@3.24.1)':
     dependencies:
-      '@tanstack/vue-query': 5.59.16(vue@3.5.32(typescript@5.6.2))
+      '@tanstack/vue-query': 5.59.16(vue@3.5.34(typescript@5.6.2))
       '@wagmi/connectors': 5.7.12(@types/react@19.1.8)(@wagmi/core@2.16.7(@tanstack/query-core@5.59.16)(@types/react@19.1.8)(immer@10.0.2)(react@18.3.1)(typescript@5.6.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1)))(bufferutil@4.0.8)(ioredis@5.4.1)(react@18.3.1)(typescript@5.6.2)(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
       '@wagmi/core': 2.16.7(@tanstack/query-core@5.59.16)(@types/react@19.1.8)(immer@10.0.2)(react@18.3.1)(typescript@5.6.2)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1))
       viem: 2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1)
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
     optionalDependencies:
       nuxt: 3.13.2(@parcel/watcher@2.4.1)(@types/node@24.3.3)(bufferutil@4.0.8)(eslint@9.11.1(jiti@2.4.2))(idb-keyval@6.2.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))
       typescript: 5.6.2
@@ -17537,7 +17546,7 @@ snapshots:
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.3
+      fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -17820,6 +17829,8 @@ snapshots:
       b4a: 1.6.7
       nanoassert: 2.0.0
 
+  blakejs@1.2.1: {}
+
   bluebird@3.7.2: {}
 
   bn.js@4.12.0: {}
@@ -17909,7 +17920,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bun-types@1.3.12:
+  bun-types@1.3.13:
     dependencies:
       '@types/node': 22.15.33
 
@@ -19382,8 +19393,6 @@ snapshots:
 
   fast-uri@2.4.0: {}
 
-  fast-uri@3.0.3: {}
-
   fast-uri@3.1.0: {}
 
   fastfile@0.0.20: {}
@@ -19392,11 +19401,11 @@ snapshots:
 
   fastify-plugin@5.1.0: {}
 
-  fastify-type-provider-zod@6.1.0(@fastify/swagger@9.6.1)(fastify@5.7.4)(openapi-types@12.1.3)(zod@4.2.1):
+  fastify-type-provider-zod@6.1.0(@fastify/swagger@9.6.1)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.2.1):
     dependencies:
       '@fastify/error': 4.2.0
       '@fastify/swagger': 9.6.1
-      fastify: 5.7.4
+      fastify: 5.8.5
       openapi-types: 12.1.3
       zod: 4.2.1
 
@@ -19419,7 +19428,7 @@ snapshots:
       semver: 7.6.3
       toad-cache: 3.7.0
 
-  fastify@5.7.4:
+  fastify@5.8.5:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0
@@ -20981,15 +20990,15 @@ snapshots:
   nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@22.8.0)(bufferutil@4.0.8)(eslint@9.11.1(jiti@2.4.2))(idb-keyval@6.2.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.6.0(bufferutil@4.0.8)(rollup@4.30.1)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))
+      '@nuxt/devtools': 1.6.0(bufferutil@4.0.8)(rollup@4.30.1)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.30.1)
       '@nuxt/schema': 3.13.2(rollup@4.30.1)
       '@nuxt/telemetry': 2.6.0(magicast@0.3.5)(rollup@4.30.1)
-      '@nuxt/vite-builder': 3.13.2(@types/node@22.8.0)(eslint@9.11.1(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(vue@3.5.32(typescript@5.6.2))
+      '@nuxt/vite-builder': 3.13.2(@types/node@22.8.0)(eslint@9.11.1(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(vue@3.5.34(typescript@5.6.2))
       '@unhead/dom': 1.11.10
       '@unhead/shared': 1.11.10
       '@unhead/ssr': 1.11.10
-      '@unhead/vue': 1.11.10(vue@3.5.32(typescript@5.6.2))
+      '@unhead/vue': 1.11.10(vue@3.5.34(typescript@5.6.2))
       '@vue/shared': 3.5.12
       acorn: 8.12.1
       c12: 1.11.2(magicast@0.3.5)
@@ -21037,13 +21046,13 @@ snapshots:
       unhead: 1.11.10
       unimport: 3.13.1(rollup@4.30.1)
       unplugin: 1.14.1
-      unplugin-vue-router: 0.10.8(rollup@4.30.1)(vue-router@4.4.5(vue@3.5.32(typescript@5.6.2)))(vue@3.5.32(typescript@5.6.2))
+      unplugin-vue-router: 0.10.8(rollup@4.30.1)(vue-router@4.4.5(vue@3.5.34(typescript@5.6.2)))(vue@3.5.34(typescript@5.6.2))
       unstorage: 1.12.0(idb-keyval@6.2.1)(ioredis@5.4.1)
       untyped: 1.5.1
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
       vue-bundle-renderer: 2.1.1
       vue-devtools-stub: 0.1.0
-      vue-router: 4.4.5(vue@3.5.32(typescript@5.6.2))
+      vue-router: 4.4.5(vue@3.5.34(typescript@5.6.2))
     optionalDependencies:
       '@parcel/watcher': 2.4.1
       '@types/node': 22.8.0
@@ -21094,15 +21103,15 @@ snapshots:
   nuxt@3.13.2(@parcel/watcher@2.4.1)(@types/node@24.3.3)(bufferutil@4.0.8)(eslint@9.11.1(jiti@2.4.2))(idb-keyval@6.2.1)(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.6.0(bufferutil@4.0.8)(rollup@4.30.1)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.32(typescript@5.6.2))
+      '@nuxt/devtools': 1.6.0(bufferutil@4.0.8)(rollup@4.30.1)(utf-8-validate@5.0.10)(vite@5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0))(vue@3.5.34(typescript@5.6.2))
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.30.1)
       '@nuxt/schema': 3.13.2(rollup@4.30.1)
       '@nuxt/telemetry': 2.6.0(magicast@0.3.5)(rollup@4.30.1)
-      '@nuxt/vite-builder': 3.13.2(@types/node@24.3.3)(eslint@9.11.1(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(vue@3.5.32(typescript@5.6.2))
+      '@nuxt/vite-builder': 3.13.2(@types/node@24.3.3)(eslint@9.11.1(jiti@2.4.2))(magicast@0.3.5)(optionator@0.9.4)(rollup@4.30.1)(sass@1.80.4)(terser@5.36.0)(typescript@5.6.2)(vue@3.5.34(typescript@5.6.2))
       '@unhead/dom': 1.11.10
       '@unhead/shared': 1.11.10
       '@unhead/ssr': 1.11.10
-      '@unhead/vue': 1.11.10(vue@3.5.32(typescript@5.6.2))
+      '@unhead/vue': 1.11.10(vue@3.5.34(typescript@5.6.2))
       '@vue/shared': 3.5.12
       acorn: 8.12.1
       c12: 1.11.2(magicast@0.3.5)
@@ -21150,13 +21159,13 @@ snapshots:
       unhead: 1.11.10
       unimport: 3.13.1(rollup@4.30.1)
       unplugin: 1.14.1
-      unplugin-vue-router: 0.10.8(rollup@4.30.1)(vue-router@4.4.5(vue@3.5.32(typescript@5.6.2)))(vue@3.5.32(typescript@5.6.2))
+      unplugin-vue-router: 0.10.8(rollup@4.30.1)(vue-router@4.4.5(vue@3.5.34(typescript@5.6.2)))(vue@3.5.34(typescript@5.6.2))
       unstorage: 1.12.0(idb-keyval@6.2.1)(ioredis@5.4.1)
       untyped: 1.5.1
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
       vue-bundle-renderer: 2.1.1
       vue-devtools-stub: 0.1.0
-      vue-router: 4.4.5(vue@3.5.32(typescript@5.6.2))
+      vue-router: 4.4.5(vue@3.5.34(typescript@5.6.2))
     optionalDependencies:
       '@parcel/watcher': 2.4.1
       '@types/node': 24.3.3
@@ -21284,7 +21293,7 @@ snapshots:
       npm-run-path: 4.0.1
       open: 8.4.2
       ora: 5.3.0
-      semver: 7.6.3
+      semver: 7.7.3
       string-width: 4.2.3
       strong-log-transformer: 2.1.0
       tar-stream: 2.2.0
@@ -21707,7 +21716,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -21764,11 +21773,11 @@ snapshots:
 
   pify@5.0.0: {}
 
-  pinia@2.2.4(typescript@5.6.2)(vue@3.5.32(typescript@5.6.2)):
+  pinia@2.2.4(typescript@5.6.2)(vue@3.5.34(typescript@5.6.2)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.32(typescript@5.6.2)
-      vue-demi: 0.14.10(vue@3.5.32(typescript@5.6.2))
+      vue: 3.5.34(typescript@5.6.2)
+      vue-demi: 0.14.10(vue@3.5.34(typescript@5.6.2))
     optionalDependencies:
       typescript: 5.6.2
 
@@ -22131,6 +22140,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -22175,15 +22190,16 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  prividium@0.15.1(@fastify/swagger@9.6.1)(bufferutil@4.0.8)(openapi-types@12.1.3)(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1)):
+  prividium@0.18.0(@fastify/swagger@9.6.1)(bufferutil@4.0.8)(openapi-types@12.1.3)(utf-8-validate@5.0.10)(viem@2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1)):
     dependencies:
       '@clack/prompts': 0.11.0
-      '@fastify/http-proxy': 11.4.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      '@fastify/http-proxy': 11.4.4(bufferutil@4.0.8)(utf-8-validate@5.0.10)
       '@fastify/static': 9.0.0
       appdirsjs: 1.2.7
+      blakejs: 1.2.1
       date-fns: 4.1.0
-      fastify: 5.7.4
-      fastify-type-provider-zod: 6.1.0(@fastify/swagger@9.6.1)(fastify@5.7.4)(openapi-types@12.1.3)(zod@4.2.1)
+      fastify: 5.8.5
+      fastify-type-provider-zod: 6.1.0(@fastify/swagger@9.6.1)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.2.1)
       kleur: 4.1.5
       open: 10.1.0
       viem: 2.30.0(bufferutil@4.0.8)(typescript@5.6.2)(utf-8-validate@5.0.10)(zod@3.24.1)
@@ -22297,20 +22313,20 @@ snapshots:
       fastfile: 0.0.20
       ffjavascript: 0.3.0
 
-  radix-vue@1.9.7(vue@3.5.32(typescript@5.6.2)):
+  radix-vue@1.9.7(vue@3.5.34(typescript@5.6.2)):
     dependencies:
       '@floating-ui/dom': 1.6.11
-      '@floating-ui/vue': 1.1.5(vue@3.5.32(typescript@5.6.2))
+      '@floating-ui/vue': 1.1.5(vue@3.5.34(typescript@5.6.2))
       '@internationalized/date': 3.5.6
       '@internationalized/number': 3.5.4
-      '@tanstack/vue-virtual': 3.10.8(vue@3.5.32(typescript@5.6.2))
-      '@vueuse/core': 10.11.1(vue@3.5.32(typescript@5.6.2))
-      '@vueuse/shared': 10.11.1(vue@3.5.32(typescript@5.6.2))
+      '@tanstack/vue-virtual': 3.10.8(vue@3.5.34(typescript@5.6.2))
+      '@vueuse/core': 10.11.1(vue@3.5.34(typescript@5.6.2))
+      '@vueuse/shared': 10.11.1(vue@3.5.34(typescript@5.6.2))
       aria-hidden: 1.2.4
       defu: 6.1.4
       fast-deep-equal: 3.1.3
       nanoid: 5.0.7
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -23369,11 +23385,11 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-vue-router@0.10.8(rollup@4.30.1)(vue-router@4.4.5(vue@3.5.32(typescript@5.6.2)))(vue@3.5.32(typescript@5.6.2)):
+  unplugin-vue-router@0.10.8(rollup@4.30.1)(vue-router@4.4.5(vue@3.5.34(typescript@5.6.2)))(vue@3.5.34(typescript@5.6.2)):
     dependencies:
       '@babel/types': 7.26.0
       '@rollup/pluginutils': 5.1.3(rollup@4.30.1)
-      '@vue-macros/common': 1.15.0(rollup@4.30.1)(vue@3.5.32(typescript@5.6.2))
+      '@vue-macros/common': 1.15.0(rollup@4.30.1)(vue@3.5.34(typescript@5.6.2))
       ast-walker-scope: 0.6.2
       chokidar: 3.6.0
       fast-glob: 3.3.2
@@ -23386,7 +23402,7 @@ snapshots:
       unplugin: 1.14.1
       yaml: 2.6.0
     optionalDependencies:
-      vue-router: 4.4.5(vue@3.5.32(typescript@5.6.2))
+      vue-router: 4.4.5(vue@3.5.34(typescript@5.6.2))
     transitivePeerDependencies:
       - rollup
       - vue
@@ -23819,7 +23835,7 @@ snapshots:
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.26.0)
       '@babel/plugin-transform-typescript': 7.25.9(@babel/core@7.26.0)
       '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.26.0)
-      '@vue/compiler-dom': 3.5.31
+      '@vue/compiler-dom': 3.5.32
       kolorist: 1.8.0
       magic-string: 0.30.21
       vite: 5.4.10(@types/node@22.8.0)(sass@1.80.4)(terser@5.36.0)
@@ -23834,7 +23850,7 @@ snapshots:
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.26.0)
       '@babel/plugin-transform-typescript': 7.25.9(@babel/core@7.26.0)
       '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.26.0)
-      '@vue/compiler-dom': 3.5.31
+      '@vue/compiler-dom': 3.5.32
       kolorist: 1.8.0
       magic-string: 0.30.21
       vite: 5.4.10(@types/node@24.3.3)(sass@1.80.4)(terser@5.36.0)
@@ -24024,9 +24040,9 @@ snapshots:
     dependencies:
       ufo: 1.5.4
 
-  vue-demi@0.14.10(vue@3.5.32(typescript@5.6.2)):
+  vue-demi@0.14.10(vue@3.5.34(typescript@5.6.2)):
     dependencies:
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
 
   vue-devtools-stub@0.1.0: {}
 
@@ -24043,10 +24059,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@4.4.5(vue@3.5.32(typescript@5.6.2)):
+  vue-router@4.4.5(vue@3.5.34(typescript@5.6.2)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
 
   vue@3.5.13(typescript@5.6.2):
     dependencies:
@@ -24058,13 +24074,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.2
 
-  vue@3.5.32(typescript@5.6.2):
+  vue@3.5.34(typescript@5.6.2):
     dependencies:
-      '@vue/compiler-dom': 3.5.32
-      '@vue/compiler-sfc': 3.5.32
-      '@vue/runtime-dom': 3.5.32
-      '@vue/server-renderer': 3.5.32(vue@3.5.32(typescript@5.6.2))
-      '@vue/shared': 3.5.32
+      '@vue/compiler-dom': 3.5.34
+      '@vue/compiler-sfc': 3.5.34
+      '@vue/runtime-dom': 3.5.34
+      '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@5.6.2))
+      '@vue/shared': 3.5.34
     optionalDependencies:
       typescript: 5.6.2
 
@@ -24120,9 +24136,9 @@ snapshots:
 
   web-worker@1.2.0: {}
 
-  web3-avatar-vue@1.0.5(vue@3.5.32(typescript@5.6.2)):
+  web3-avatar-vue@1.0.5(vue@3.5.34(typescript@5.6.2)):
     dependencies:
-      vue: 3.5.32(typescript@5.6.2)
+      vue: 3.5.34(typescript@5.6.2)
       web3-avatar: 1.0.5
 
   web3-avatar@1.0.5: {}


### PR DESCRIPTION
## Summary
- send the contract disclosure field expected by Prividium
- use plain API requests with cached auth headers and one 401 reauth retry
- avoid reusing one captured auth header set across post-deploy calls