### PR TITLE
[codex] fix: disable auth API Express header

### DIFF
--- a/packages/auth-server-api/src/app.ts
+++ b/packages/auth-server-api/src/app.ts
@@ -2,12 +2,13 @@ import cors from "cors";
 import express, { type NextFunction, type Request, type Response } from "express";
 
 import { env, prividiumConfig } from "./config.js";
+import { createExpressApp } from "./create-express-app.js";
 import { deployAccountHandler } from "./handlers/deploy-account.js";
 import { prividiumAuthMiddleware } from "./middleware/prividium-auth.js";
 import { deployLimiter } from "./middleware/rate-limit.js";
 
 // Initialize Express app
-const app = express();
+const app = createExpressApp();
 
 // Middleware
 app.use(express.json());

--- a/packages/auth-server-api/src/create-express-app.ts
+++ b/packages/auth-server-api/src/create-express-app.ts
@@ -1,0 +1,7 @@
+import express from "express";
+
+export function createExpressApp() {
+  const app = express();
+  app.disable("x-powered-by");
+  return app;
+}

--- a/packages/auth-server-api/test/create-express-app.test.ts
+++ b/packages/auth-server-api/test/create-express-app.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import type { Server } from "node:http";
+import { after, before, describe, it } from "node:test";
+
+import { createExpressApp } from "../src/create-express-app.ts";
+
+const app = createExpressApp();
+let server: Server | undefined;
+
+before(async () => {
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok" });
+  });
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, resolve);
+  });
+});
+
+after(() => {
+  server?.close();
+});
+
+describe("createExpressApp", () => {
+  it("does not expose Express fingerprinting headers", async () => {
+    assert(server);
+    const address = server.address();
+    assert(address && typeof address === "object");
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/health`);
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.has("x-powered-by"), false);
+  });
+});


### PR DESCRIPTION
# What

- Centralized auth-server-api Express app creation in `createExpressApp`.
- Disabled Express `X-Powered-By` fingerprinting headers at app construction.
- Added a regression test that serves a real response and asserts the header is absent.

# Why

The Prividium DAST scan flagged `X-Powered-By: Express` on the local SSO auth API target. This repository owns the `sso-auth-server-api` image, so the durable fix belongs in this source app rather than only in downstream compose wiring.

# Validation

- `pnpm eslint packages/auth-server-api/src/app.ts packages/auth-server-api/src/create-express-app.ts packages/auth-server-api/test/create-express-app.test.ts`
- `pnpm --filter auth-server-api test`
- `pnpm --filter auth-server-api build`
- `forge soldeer install`
- `forge build`
- `env npm_config_script_shell=/bin/bash pnpm --filter zksync-sso build`

Notes: the Foundry build reports existing lint/compiler warnings, and npm reports existing config warnings during SDK build.
